### PR TITLE
Updated CMake Configuration: vcpkg Integration and Preset Addition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,18 @@ IF(BUILD_SHARED_LIBS)
     SET(CMAKE_LIBRARY_OUTPUT_DIRECTORY "../../lib")
 ENDIF()
 
+include(FetchContent)
+
+FetchContent_Declare(
+  vcpkg
+  GIT_REPOSITORY https://github.com/microsoft/vcpkg.git
+  GIT_TAG 2024.07.12
+)
+
+FetchContent_MakeAvailable(vcpkg)
+
+set(CMAKE_TOOLCHAIN_FILE "${vcpkg_SOURCE_DIR}/scripts/buildsystems/vcpkg.cmake")
+
 # set the project name
 PROJECT(${PROJECT_NAME} VERSION 1.0.0.0)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,11 @@
+{
+  "version": 2,
+  "configurePresets": [
+    {
+      "name": "default",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/",
+      "cacheVariables": {}
+    }
+  ]
+}


### PR DESCRIPTION
## 목적
This PR integrates the FetchContent module into the CMake build system to streamline the inclusion of dependencies, specifically vcpkg. It also introduces a new CMake preset for consistent build configurations.

## 변경 사항
**CMakeLists.txt:**
- Added include(FetchContent) to incorporate the FetchContent module.
- Declared vcpkg using FetchContent_Declare, specifying the Git repository and tag.
- Enabled the use of vcpkg with FetchContent_MakeAvailable.
- Set CMAKE_TOOLCHAIN_FILE to point to the vcpkg toolchain file.

**CMakePresets.json:**
- Defined a new CMake preset as a JSON object.
- Set version to 2 and added a default preset within the configurePresets array.
- Configured the default preset to use the Ninja build system and set the binary directory to ${sourceDir}/build/.
- Initialized cacheVariables as an empty object for flexibility.

## TODO (Optional)
Verify compatibility with additional platforms using the new preset.
Update project documentation to reflect the new build process.
ex) readme.md update
cmake --preset default
cmake --build build

## Followers (Optional)
