### PR TITLE
Fix build errors and eliminate compilation warnings

### DIFF
--- a/application_layer/src/kcenon/messaging/core/message_bus.cpp
+++ b/application_layer/src/kcenon/messaging/core/message_bus.cpp
@@ -279,7 +279,7 @@ namespace kcenon::messaging::core {
         return future;
     }
 
-    void message_bus::respond(const message& original_msg, const message& response_msg) {
+    void message_bus::respond(const message& /* original_msg */, const message& response_msg) {
         // Simplified - in production would correlate with pending requests
         publish(response_msg);
     }
@@ -319,7 +319,7 @@ namespace kcenon::messaging::core {
         return !msg.payload.topic.empty() && !msg.metadata.id.empty();
     }
 
-    void message_bus::update_statistics(const message& msg, bool success) {
+    void message_bus::update_statistics(const message& /* msg */, bool /* success */) {
         // Additional statistics tracking can be added here
         // For now, this is handled in specific methods
     }

--- a/application_layer/src/services/container/container_service.cpp
+++ b/application_layer/src/services/container/container_service.cpp
@@ -419,27 +419,27 @@ namespace kcenon::messaging::services::container {
         }
     }
 
-    void container_service::process_serialize_request(const core::message& msg) {
+    void container_service::process_serialize_request(const core::message& /* msg */) {
         // Implementation would extract payload from message and serialize it
         stats_.serializations.fetch_add(1);
     }
 
-    void container_service::process_deserialize_request(const core::message& msg) {
+    void container_service::process_deserialize_request(const core::message& /* msg */) {
         // Implementation would extract binary data and deserialize it
         stats_.deserializations.fetch_add(1);
     }
 
-    void container_service::process_validate_request(const core::message& msg) {
+    void container_service::process_validate_request(const core::message& /* msg */) {
         // Implementation would validate the message payload
         stats_.validations.fetch_add(1);
     }
 
-    void container_service::process_compress_request(const core::message& msg) {
+    void container_service::process_compress_request(const core::message& /* msg */) {
         // Implementation would compress the message data
         stats_.compressions.fetch_add(1);
     }
 
-    void container_service::process_decompress_request(const core::message& msg) {
+    void container_service::process_decompress_request(const core::message& /* msg */) {
         // Implementation would decompress the message data
         stats_.compressions.fetch_add(1);
     }

--- a/application_layer/src/services/network/network_service.cpp
+++ b/application_layer/src/services/network/network_service.cpp
@@ -113,7 +113,7 @@ namespace kcenon::messaging::services::network {
         }
     }
 
-    bool network_service::broadcast_message(const core::message& msg) {
+    bool network_service::broadcast_message(const core::message& /* msg */) {
         if (state_ != service_state::running) {
             return false;
         }

--- a/src/integration/network_bridge.cpp
+++ b/src/integration/network_bridge.cpp
@@ -12,10 +12,10 @@ MessagingNetworkBridge::MessagingNetworkBridge(
     std::shared_ptr<common::interfaces::IExecutor> io_executor,
     std::shared_ptr<common::interfaces::IExecutor> work_executor,
     std::shared_ptr<MessageBus> message_bus
-) : port_(port),
-    io_executor_(io_executor),
+) : io_executor_(io_executor),
     work_executor_(work_executor),
     message_bus_(message_bus),
+    port_(port),
     running_(false) {
 
     if (!message_bus) {


### PR DESCRIPTION
## Summary
This PR resolves critical build errors and eliminates all compilation warnings in the messaging_system project, achieving a clean build with zero warnings.

## Changes

### 1. Fix Result<void> Type Errors
- **Issue**: C++ does not allow void as a reference type
- **Solution**: 
  - Changed `Result<void>` to `VoidResult` type alias
  - Replaced `VoidResult::ok()` with `common::ok()`
- **Files**: `examples/basic_messaging.cpp`

### 2. Simplify Executor Usage
- **Issue**: Complex thread_pool integration with lambda copy-constructor issues
- **Solution**:
  - Replaced `thread_pool` with `MockExecutor`
  - Removed thread_system dependency complexity
  - Eliminated unnecessary `HAS_THREAD_SYSTEM` conditionals
- **Files**: `examples/basic_messaging.cpp`

### 3. Remove Unused Parameter Warnings (10 warnings)
- **Files and fixes**:
  - `message_bus.cpp`: Marked `original_msg`, `msg`, `success` as intentionally unused
  - `container_service.cpp`: Marked `msg` parameter as unused in 5 methods
  - `network_service.cpp`: Marked `msg` parameter as unused

### 4. Fix Member Initialization Order Warning
- **Issue**: Initializer list order didn't match member declaration order
- **Solution**: Reordered initializer list in constructor
- **Files**: `network_bridge.cpp`

## Build Status

### Before
- messaging_system warnings: **10**
- Build: ❌ **FAILED**

### After
- messaging_system warnings: **0** ✅
- Build: ✅ **SUCCESS**
- All tests: ✅ **PASSING**

## Impact
- **Code Quality**: Achieved zero-warning build
- **Maintainability**: Cleaner, more maintainable code
- **Reliability**: All tests passing
- **Dependencies**: Simplified executor dependencies

## Files Changed
```
application_layer/src/kcenon/messaging/core/message_bus.cpp
application_layer/src/services/container/container_service.cpp
application_layer/src/services/network/network_service.cpp
examples/basic_messaging.cpp
src/integration/network_bridge.cpp
```

**Total**: 5 files changed, 19 insertions(+), 27 deletions(-)

## Testing
- ✅ Clean build with `./build.sh --clean`
- ✅ All unit tests passing
- ✅ Integration tests passing
- ✅ Example program builds and runs successfully

## Note
External system warnings (common_system, network_system, logger_system) remain unchanged as they are maintained in separate repositories.