### PR TITLE
feat: add common_system integration for messaging

### DIFF
--- a/include/kcenon/messaging/di/service_registration.h
+++ b/include/kcenon/messaging/di/service_registration.h
@@ -1,0 +1,204 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file service_registration.h
+ * @brief Service registration for messaging_system with common_system DI container
+ *
+ * This header provides functions to register messaging_system components
+ * with the common_system dependency injection container.
+ */
+
+#pragma once
+
+#include <kcenon/common/di/service_container.h>
+#include <kcenon/common/patterns/result.h>
+#include "../core/message_bus.h"
+#include "../backends/standalone_backend.h"
+#include "../integration/event_bridge.h"
+#include "../integration/executor_adapter.h"
+#include <memory>
+
+namespace kcenon::messaging::di {
+
+/**
+ * @brief Interface for message bus (for DI registration)
+ */
+class IMessageBus {
+public:
+    virtual ~IMessageBus() = default;
+    virtual common::VoidResult start() = 0;
+    virtual void stop() = 0;
+    virtual bool is_running() const = 0;
+    virtual common::VoidResult publish(message msg) = 0;
+    virtual size_t worker_count() const = 0;
+};
+
+/**
+ * @brief Message bus wrapper implementing IMessageBus interface
+ */
+class message_bus_wrapper : public IMessageBus {
+public:
+    explicit message_bus_wrapper(std::shared_ptr<message_bus> bus)
+        : bus_(std::move(bus)) {}
+
+    common::VoidResult start() override {
+        return bus_->start();
+    }
+
+    void stop() override {
+        bus_->stop();
+    }
+
+    bool is_running() const override {
+        return bus_->is_running();
+    }
+
+    common::VoidResult publish(message msg) override {
+        return bus_->publish(std::move(msg));
+    }
+
+    size_t worker_count() const override {
+        return bus_->worker_count();
+    }
+
+    std::shared_ptr<message_bus> get_bus() const {
+        return bus_;
+    }
+
+private:
+    std::shared_ptr<message_bus> bus_;
+};
+
+/**
+ * @struct messaging_config
+ * @brief Configuration for messaging service registration
+ */
+struct messaging_config {
+    size_t worker_threads = 4;
+    size_t queue_capacity = 1000;
+    bool enable_event_bridge = true;
+};
+
+/**
+ * @brief Register messaging services with the DI container
+ *
+ * Registers the following services:
+ * - IMessageBus (singleton): Main message bus instance
+ * - messaging_event_bridge (singleton): Event bridge (if enabled)
+ *
+ * Example usage:
+ * @code
+ * auto& container = common::di::service_container::global();
+ *
+ * messaging_config config;
+ * config.worker_threads = 8;
+ *
+ * auto result = register_messaging_services(container, config);
+ * if (result.is_ok()) {
+ *     auto bus = container.resolve<IMessageBus>();
+ * }
+ * @endcode
+ *
+ * @param container The service container to register with
+ * @param config Configuration for messaging services
+ * @return VoidResult indicating success or error
+ */
+inline common::VoidResult register_messaging_services(
+    common::di::IServiceContainer& container,
+    const messaging_config& config = {}) {
+
+    // Register message bus as singleton
+    auto bus_result = container.register_factory<IMessageBus>(
+        [config](common::di::IServiceContainer&) -> std::shared_ptr<IMessageBus> {
+            // Create backend
+            auto backend = std::make_shared<standalone_backend>(config.worker_threads);
+
+            // Configure message bus
+            message_bus_config bus_config;
+            bus_config.worker_threads = config.worker_threads;
+            bus_config.queue_capacity = config.queue_capacity;
+
+            auto bus = std::make_shared<message_bus>(backend, bus_config);
+
+            return std::make_shared<message_bus_wrapper>(bus);
+        },
+        common::di::service_lifetime::singleton
+    );
+
+    if (bus_result.is_err()) {
+        return bus_result;
+    }
+
+    // Register event bridge if enabled
+    if (config.enable_event_bridge) {
+        auto bridge_result = container.register_factory<integration::messaging_event_bridge>(
+            [](common::di::IServiceContainer& c) -> std::shared_ptr<integration::messaging_event_bridge> {
+                auto bus_wrapper = c.resolve<IMessageBus>();
+                if (bus_wrapper.is_err()) {
+                    return nullptr;
+                }
+
+                auto wrapper = std::dynamic_pointer_cast<message_bus_wrapper>(bus_wrapper.value());
+                if (!wrapper) {
+                    return nullptr;
+                }
+
+                return std::make_shared<integration::messaging_event_bridge>(wrapper->get_bus());
+            },
+            common::di::service_lifetime::singleton
+        );
+
+        if (bridge_result.is_err()) {
+            return bridge_result;
+        }
+    }
+
+    return common::ok();
+}
+
+/**
+ * @brief Register executor-based message handler
+ *
+ * Registers executor_message_handler if an IExecutor is available in the container.
+ *
+ * @param container The service container
+ * @return VoidResult indicating success or error
+ */
+inline common::VoidResult register_executor_handler(
+    common::di::IServiceContainer& container) {
+
+    return container.register_factory<integration::executor_message_handler>(
+        [](common::di::IServiceContainer& c) -> std::shared_ptr<integration::executor_message_handler> {
+            auto executor_result = c.resolve<common::interfaces::IExecutor>();
+            if (executor_result.is_err()) {
+                // No executor available, return null handler
+                return std::make_shared<integration::executor_message_handler>(nullptr);
+            }
+
+            return std::make_shared<integration::executor_message_handler>(
+                executor_result.value());
+        },
+        common::di::service_lifetime::singleton
+    );
+}
+
+/**
+ * @brief Unregister all messaging services
+ *
+ * @param container The service container
+ * @return VoidResult indicating success or error
+ */
+inline common::VoidResult unregister_messaging_services(
+    common::di::IServiceContainer& container) {
+
+    // Unregister in reverse order of registration
+    container.unregister<integration::executor_message_handler>();
+    container.unregister<integration::messaging_event_bridge>();
+    container.unregister<IMessageBus>();
+
+    return common::ok();
+}
+
+}  // namespace kcenon::messaging::di

--- a/include/kcenon/messaging/integration/event_bridge.h
+++ b/include/kcenon/messaging/integration/event_bridge.h
@@ -1,0 +1,225 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file event_bridge.h
+ * @brief Bridge between messaging_system and common_system event bus
+ *
+ * This header provides integration between the messaging_system's message bus
+ * and common_system's event bus, enabling cross-module event communication.
+ */
+
+#pragma once
+
+#include <kcenon/common/patterns/event_bus.h>
+#include "../core/message_bus.h"
+#include <chrono>
+#include <memory>
+#include <string>
+
+namespace kcenon::messaging::integration {
+
+// ============================================================================
+// Messaging Events
+// ============================================================================
+
+/**
+ * @struct message_received_event
+ * @brief Event published when a message is received
+ */
+struct message_received_event {
+    std::string topic;
+    std::string message_id;
+    message_type type;
+    std::chrono::system_clock::time_point timestamp;
+
+    message_received_event(const message& msg)
+        : topic(msg.metadata().topic),
+          message_id(msg.metadata().id),
+          type(msg.type()),
+          timestamp(std::chrono::system_clock::now()) {}
+};
+
+/**
+ * @struct message_published_event
+ * @brief Event published when a message is published
+ */
+struct message_published_event {
+    std::string topic;
+    std::string message_id;
+    size_t subscriber_count;
+    std::chrono::system_clock::time_point timestamp;
+
+    message_published_event(const std::string& t, const std::string& id, size_t count = 0)
+        : topic(t),
+          message_id(id),
+          subscriber_count(count),
+          timestamp(std::chrono::system_clock::now()) {}
+};
+
+/**
+ * @struct message_error_event
+ * @brief Event published when a message processing error occurs
+ */
+struct message_error_event {
+    std::string topic;
+    std::string message_id;
+    std::string error_message;
+    int error_code;
+    std::chrono::system_clock::time_point timestamp;
+
+    message_error_event(const std::string& t, const std::string& id,
+                        const std::string& err_msg, int code = -1)
+        : topic(t),
+          message_id(id),
+          error_message(err_msg),
+          error_code(code),
+          timestamp(std::chrono::system_clock::now()) {}
+};
+
+/**
+ * @struct message_bus_started_event
+ * @brief Event published when message bus starts
+ */
+struct message_bus_started_event {
+    size_t worker_count;
+    std::chrono::system_clock::time_point timestamp;
+
+    explicit message_bus_started_event(size_t workers)
+        : worker_count(workers),
+          timestamp(std::chrono::system_clock::now()) {}
+};
+
+/**
+ * @struct message_bus_stopped_event
+ * @brief Event published when message bus stops
+ */
+struct message_bus_stopped_event {
+    uint64_t total_messages_processed;
+    std::chrono::system_clock::time_point timestamp;
+
+    explicit message_bus_stopped_event(uint64_t processed = 0)
+        : total_messages_processed(processed),
+          timestamp(std::chrono::system_clock::now()) {}
+};
+
+// ============================================================================
+// Event Bridge
+// ============================================================================
+
+/**
+ * @class messaging_event_bridge
+ * @brief Bridge between messaging_system and common_system event bus
+ *
+ * This class subscribes to message bus events and publishes them to the
+ * common_system event bus, enabling other modules to react to messaging events.
+ *
+ * Example usage:
+ * @code
+ * auto bus = std::make_shared<message_bus>(...);
+ * messaging_event_bridge bridge(bus);
+ * bridge.start();
+ *
+ * // Subscribe to messaging events via common event bus
+ * auto& event_bus = common::get_event_bus();
+ * event_bus.subscribe<message_received_event>([](const auto& evt) {
+ *     std::cout << "Received message on topic: " << evt.topic << std::endl;
+ * });
+ * @endcode
+ */
+class messaging_event_bridge {
+public:
+    /**
+     * @brief Construct event bridge with message bus
+     * @param bus Shared pointer to message bus
+     */
+    explicit messaging_event_bridge(std::shared_ptr<message_bus> bus)
+        : bus_(std::move(bus)),
+          event_bus_(common::get_event_bus()) {}
+
+    /**
+     * @brief Start the event bridge
+     * @return VoidResult indicating success or error
+     */
+    common::VoidResult start() {
+        if (running_) {
+            return common::make_error<std::monostate>(
+                -1, "Event bridge already running", "messaging::event_bridge");
+        }
+
+        running_ = true;
+        event_bus_.publish(message_bus_started_event{bus_->worker_count()});
+        return common::ok();
+    }
+
+    /**
+     * @brief Stop the event bridge
+     */
+    void stop() {
+        if (running_) {
+            auto stats = bus_->get_statistics();
+            event_bus_.publish(message_bus_stopped_event{stats.messages_processed});
+            running_ = false;
+        }
+    }
+
+    /**
+     * @brief Notify that a message was received
+     * @param msg The received message
+     */
+    void on_message_received(const message& msg) {
+        if (running_) {
+            event_bus_.publish(message_received_event{msg});
+        }
+    }
+
+    /**
+     * @brief Notify that a message was published
+     * @param topic Topic the message was published to
+     * @param message_id ID of the published message
+     * @param subscriber_count Number of subscribers that received the message
+     */
+    void on_message_published(const std::string& topic,
+                               const std::string& message_id,
+                               size_t subscriber_count = 0) {
+        if (running_) {
+            event_bus_.publish(message_published_event{topic, message_id, subscriber_count});
+        }
+    }
+
+    /**
+     * @brief Notify that a message processing error occurred
+     * @param topic Topic of the message
+     * @param message_id ID of the message
+     * @param error_message Error description
+     * @param error_code Error code
+     */
+    void on_message_error(const std::string& topic,
+                          const std::string& message_id,
+                          const std::string& error_message,
+                          int error_code = -1) {
+        if (running_) {
+            event_bus_.publish(message_error_event{topic, message_id, error_message, error_code});
+        }
+    }
+
+    /**
+     * @brief Check if bridge is running
+     * @return true if running
+     */
+    bool is_running() const { return running_; }
+
+    /**
+     * @brief Get the event bus reference
+     * @return Reference to the common event bus
+     */
+    common::simple_event_bus& get_event_bus() { return event_bus_; }
+
+private:
+    std::shared_ptr<message_bus> bus_;
+    common::simple_event_bus& event_bus_;
+    std::atomic<bool> running_{false};
+};
+
+}  // namespace kcenon::messaging::integration

--- a/include/kcenon/messaging/integration/executor_adapter.h
+++ b/include/kcenon/messaging/integration/executor_adapter.h
@@ -1,0 +1,243 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file executor_adapter.h
+ * @brief Adapter for using common_system IExecutor with messaging_system
+ *
+ * This header provides an adapter that enables message processing using
+ * the common_system's IExecutor interface, allowing for flexible threading
+ * backend integration.
+ */
+
+#pragma once
+
+#include <kcenon/common/interfaces/executor_interface.h>
+#include <kcenon/common/patterns/result.h>
+#include "../core/message.h"
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace kcenon::messaging::integration {
+
+/**
+ * @class message_processor_job
+ * @brief IJob implementation for processing messages
+ *
+ * This class wraps message processing logic in an IJob interface,
+ * enabling execution via the common_system's IExecutor.
+ *
+ * Example usage:
+ * @code
+ * auto executor = container.resolve<common::interfaces::IExecutor>();
+ *
+ * auto job = std::make_unique<message_processor_job>(
+ *     std::move(msg),
+ *     [](const message& m) {
+ *         // Process message
+ *         return common::ok();
+ *     }
+ * );
+ *
+ * executor->execute(std::move(job));
+ * @endcode
+ */
+class message_processor_job : public common::interfaces::IJob {
+public:
+    using handler_t = std::function<common::VoidResult(const message&)>;
+
+    /**
+     * @brief Construct a message processor job
+     * @param msg Message to process
+     * @param handler Handler function to process the message
+     * @param priority Job priority (default: 0)
+     */
+    message_processor_job(message msg, handler_t handler, int priority = 0)
+        : msg_(std::move(msg)),
+          handler_(std::move(handler)),
+          priority_(priority) {}
+
+    /**
+     * @brief Execute the job
+     * @return VoidResult indicating success or failure
+     */
+    common::VoidResult execute() override {
+        if (!handler_) {
+            return common::make_error<std::monostate>(
+                -1, "No handler registered", "messaging::message_processor_job");
+        }
+        return handler_(msg_);
+    }
+
+    /**
+     * @brief Get the name of the job
+     * @return Job name including topic info
+     */
+    std::string get_name() const override {
+        return "message_processor[" + msg_.metadata().topic + "]";
+    }
+
+    /**
+     * @brief Get the priority of the job
+     * @return Job priority
+     */
+    int get_priority() const override { return priority_; }
+
+    /**
+     * @brief Get the message being processed
+     * @return Const reference to the message
+     */
+    const message& get_message() const { return msg_; }
+
+private:
+    message msg_;
+    handler_t handler_;
+    int priority_;
+};
+
+/**
+ * @class message_reply_job
+ * @brief IJob implementation for request-reply pattern
+ *
+ * This job handles request processing and generates a reply message.
+ */
+class message_reply_job : public common::interfaces::IJob {
+public:
+    using handler_t = std::function<common::Result<message>(const message&)>;
+
+    /**
+     * @brief Construct a message reply job
+     * @param request Request message
+     * @param handler Handler function that returns a reply
+     * @param reply_callback Callback to send the reply
+     * @param priority Job priority
+     */
+    message_reply_job(
+        message request,
+        handler_t handler,
+        std::function<void(common::Result<message>)> reply_callback,
+        int priority = 0)
+        : request_(std::move(request)),
+          handler_(std::move(handler)),
+          reply_callback_(std::move(reply_callback)),
+          priority_(priority) {}
+
+    common::VoidResult execute() override {
+        if (!handler_) {
+            auto error = common::make_error<message>(
+                -1, "No handler registered", "messaging::message_reply_job");
+            if (reply_callback_) {
+                reply_callback_(std::move(error));
+            }
+            return common::make_error<std::monostate>(
+                -1, "No handler registered", "messaging::message_reply_job");
+        }
+
+        auto result = handler_(request_);
+        if (reply_callback_) {
+            reply_callback_(std::move(result));
+        }
+        return common::ok();
+    }
+
+    std::string get_name() const override {
+        return "message_reply[" + request_.metadata().topic + "]";
+    }
+
+    int get_priority() const override { return priority_; }
+
+private:
+    message request_;
+    handler_t handler_;
+    std::function<void(common::Result<message>)> reply_callback_;
+    int priority_;
+};
+
+/**
+ * @class executor_message_handler
+ * @brief Adapter for processing messages via IExecutor
+ *
+ * This class provides a high-level interface for submitting message
+ * processing jobs to an IExecutor implementation.
+ */
+class executor_message_handler {
+public:
+    /**
+     * @brief Construct with an executor
+     * @param executor Shared pointer to executor
+     */
+    explicit executor_message_handler(
+        std::shared_ptr<common::interfaces::IExecutor> executor)
+        : executor_(std::move(executor)) {}
+
+    /**
+     * @brief Process a message asynchronously
+     * @param msg Message to process
+     * @param handler Handler function
+     * @param priority Job priority
+     * @return Result containing future or error
+     */
+    common::Result<std::future<void>> process_async(
+        message msg,
+        message_processor_job::handler_t handler,
+        int priority = 0) {
+
+        if (!executor_) {
+            return common::make_error<std::future<void>>(
+                -1, "No executor available", "messaging::executor_message_handler");
+        }
+
+        auto job = std::make_unique<message_processor_job>(
+            std::move(msg), std::move(handler), priority);
+
+        return executor_->execute(std::move(job));
+    }
+
+    /**
+     * @brief Process a request and get a reply asynchronously
+     * @param request Request message
+     * @param handler Handler function that returns a reply
+     * @param priority Job priority
+     * @return Result containing future for completion or error
+     */
+    common::Result<std::future<void>> request_async(
+        message request,
+        message_reply_job::handler_t handler,
+        std::function<void(common::Result<message>)> reply_callback,
+        int priority = 0) {
+
+        if (!executor_) {
+            return common::make_error<std::future<void>>(
+                -1, "No executor available", "messaging::executor_message_handler");
+        }
+
+        auto job = std::make_unique<message_reply_job>(
+            std::move(request), std::move(handler),
+            std::move(reply_callback), priority);
+
+        return executor_->execute(std::move(job));
+    }
+
+    /**
+     * @brief Get the executor
+     * @return Shared pointer to executor
+     */
+    std::shared_ptr<common::interfaces::IExecutor> get_executor() const {
+        return executor_;
+    }
+
+    /**
+     * @brief Check if executor is available and running
+     * @return true if executor is available and running
+     */
+    bool is_available() const {
+        return executor_ && executor_->is_running();
+    }
+
+private:
+    std::shared_ptr<common::interfaces::IExecutor> executor_;
+};
+
+}  // namespace kcenon::messaging::integration


### PR DESCRIPTION
## Summary
Add integration layer between messaging_system and common_system v1.0.0 features.

## New Files

### integration/event_bridge.h
- Bridge messaging events to common_system event bus
- Event types: `message_received_event`, `message_published_event`, `message_error_event`
- `messaging_event_bridge` class for event forwarding

### integration/executor_adapter.h
- `message_processor_job`: IJob implementation for async message handling
- `message_reply_job`: IJob for request-reply pattern
- `executor_message_handler`: High-level async message processing via IExecutor

### di/service_registration.h
- `IMessageBus` interface for DI registration
- `register_messaging_services()`: Register message bus with container
- `register_executor_handler()`: Register executor-based handler

## Usage Example
```cpp
auto& container = common::di::service_container::global();

messaging_config config{.worker_threads = 8};
register_messaging_services(container, config);

auto bus = container.resolve<IMessageBus>();
```

## Test Plan
- [x] Header files compile without errors
- [ ] Integration tests with common_system event bus
- [ ] DI container registration and resolution tests