### PR TITLE
feat: add network transport adapters for network_system integration

### DIFF
--- a/examples/network/http_messaging.cpp
+++ b/examples/network/http_messaging.cpp
@@ -1,0 +1,349 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file http_messaging.cpp
+ * @brief Example: HTTP-based messaging with REST API
+ *
+ * Demonstrates:
+ * - HTTP transport for request/reply messaging
+ * - RESTful message API usage
+ * - JSON serialization
+ * - Error handling and retries
+ */
+
+#include <kcenon/messaging/adapters/http_transport.h>
+#include <kcenon/messaging/adapters/resilient_transport.h>
+#include <kcenon/messaging/core/message.h>
+#include <kcenon/messaging/integration/messaging_container_builder.h>
+
+#include <chrono>
+#include <format>
+#include <iostream>
+#include <thread>
+
+using namespace kcenon::messaging;
+using namespace kcenon::messaging::adapters;
+
+namespace {
+
+/**
+ * @brief Example: Order service client using HTTP
+ */
+class order_service_client {
+public:
+    explicit order_service_client(const std::string& base_url) {
+        // Configure HTTP transport
+        http_transport_config config;
+        config.host = "localhost";  // Extract from base_url in production
+        config.port = 8080;
+        config.base_path = "/api/v1";
+        config.content_type = http_content_type::json;
+        config.request_timeout = std::chrono::seconds(30);
+
+        // Set default headers
+        config.default_headers["X-API-Version"] = "1.0";
+        config.default_headers["X-Client-ID"] = "order-service-client";
+
+        // Create HTTP transport
+        auto http_transport_ptr = std::make_shared<http_transport>(config);
+
+        // Wrap with resilient transport
+        resilient_transport_config resilient_config;
+        resilient_config.retry.max_retries = 3;
+        resilient_config.retry.initial_delay = std::chrono::milliseconds(100);
+        resilient_config.retry.backoff_multiplier = 2.0;
+        resilient_config.circuit_breaker.failure_threshold = 5;
+
+        transport_ = std::make_shared<resilient_transport>(
+            http_transport_ptr, resilient_config);
+    }
+
+    /**
+     * @brief Submit a new order
+     */
+    common::Result<message> submit_order(
+        const std::string& symbol,
+        int quantity,
+        double price,
+        const std::string& side) {
+
+        // Build order message using container builder
+        auto container_result = integration::messaging_container_builder()
+            .source("order-client", "main")
+            .target("order-service", "processor")
+            .message_type("new_order")
+            .add_value("symbol", symbol)
+            .add_value("quantity", quantity)
+            .add_value("price", price)
+            .add_value("side", side)
+            .add_value("timestamp",
+                std::chrono::system_clock::now().time_since_epoch().count())
+            .build();
+
+        if (!container_result.has_value()) {
+            return common::Result<message>::err(
+                common::error_codes::INVALID_ARGUMENT,
+                "Failed to build order container");
+        }
+
+        // Create message with the container
+        auto msg_result = message_builder()
+            .topic("orders.new")
+            .source("order-client")
+            .type(message_type::command)
+            .priority(message_priority::high)
+            .payload(container_result.value())
+            .build();
+
+        if (msg_result.is_err()) {
+            return msg_result;
+        }
+
+        // Send via HTTP POST
+        auto http = std::dynamic_pointer_cast<http_transport>(
+            get_underlying_transport());
+        if (http) {
+            return http->post("/orders", msg_result.value());
+        }
+
+        // Fallback to generic send
+        auto send_result = transport_->send(msg_result.value());
+        if (send_result.is_err()) {
+            return common::Result<message>::err(send_result.error());
+        }
+        return msg_result;
+    }
+
+    /**
+     * @brief Get order status
+     */
+    common::Result<message> get_order_status(const std::string& order_id) {
+        auto http = std::dynamic_pointer_cast<http_transport>(
+            get_underlying_transport());
+        if (http) {
+            return http->get(std::format("/orders/{}", order_id));
+        }
+        return common::Result<message>::err(
+            common::error_codes::INTERNAL_ERROR,
+            "HTTP transport not available");
+    }
+
+    /**
+     * @brief Cancel an order
+     */
+    common::VoidResult cancel_order(const std::string& order_id) {
+        auto msg_result = message_builder()
+            .topic("orders.cancel")
+            .source("order-client")
+            .type(message_type::command)
+            .build();
+
+        if (msg_result.is_err()) {
+            return common::VoidResult::err(msg_result.error());
+        }
+
+        msg_result.value().payload().set_value("order_id", order_id);
+        msg_result.value().payload().set_value("reason", "user_requested");
+
+        return transport_->send(msg_result.value());
+    }
+
+    common::VoidResult connect() {
+        return transport_->connect();
+    }
+
+    void disconnect() {
+        transport_->disconnect();
+    }
+
+    void print_statistics() const {
+        auto stats = transport_->get_statistics();
+        std::cout << std::format(
+            "\n--- HTTP Transport Statistics ---\n"
+            "Messages sent: {}\n"
+            "Messages received: {}\n"
+            "Bytes sent: {}\n"
+            "Bytes received: {}\n"
+            "Errors: {}\n"
+            "Avg latency: {}ms\n",
+            stats.messages_sent,
+            stats.messages_received,
+            stats.bytes_sent,
+            stats.bytes_received,
+            stats.errors,
+            stats.avg_latency.count()
+        );
+    }
+
+private:
+    std::shared_ptr<transport_interface> get_underlying_transport() {
+        // In a real implementation, resilient_transport would expose this
+        return transport_;
+    }
+
+    std::shared_ptr<resilient_transport> transport_;
+};
+
+/**
+ * @brief Example: Notification service using HTTP
+ */
+class notification_service {
+public:
+    notification_service() {
+        http_transport_config config;
+        config.host = "notifications.example.com";
+        config.port = 443;
+        config.use_ssl = true;
+        config.base_path = "/api/notify";
+        config.content_type = http_content_type::json;
+
+        transport_ = std::make_shared<http_transport>(config);
+
+        // Set authorization header
+        transport_->set_header("Authorization", "Bearer <token>");
+    }
+
+    common::VoidResult send_notification(
+        const std::string& user_id,
+        const std::string& title,
+        const std::string& body) {
+
+        auto msg_result = message_builder()
+            .topic("notifications.push")
+            .source("notification-service")
+            .target(user_id)
+            .type(message_type::notification)
+            .build();
+
+        if (msg_result.is_err()) {
+            return common::VoidResult::err(msg_result.error());
+        }
+
+        auto& payload = msg_result.value().payload();
+        payload.set_value("title", title);
+        payload.set_value("body", body);
+        payload.set_value("sent_at",
+            std::chrono::system_clock::now().time_since_epoch().count());
+
+        return transport_->send(msg_result.value());
+    }
+
+private:
+    std::shared_ptr<http_transport> transport_;
+};
+
+} // anonymous namespace
+
+int main() {
+    std::cout << "=== HTTP Messaging Example ===\n\n";
+
+    // Example 1: Order Service Client
+    std::cout << "--- Order Service Client ---\n";
+    {
+        order_service_client client("http://localhost:8080");
+
+        std::cout << "Order service client created.\n";
+        std::cout << "In production:\n";
+        std::cout << "  client.connect();\n";
+        std::cout << "  auto result = client.submit_order(\"AAPL\", 100, 175.50, \"buy\");\n";
+        std::cout << "  auto status = client.get_order_status(\"ORD-12345\");\n";
+        std::cout << "  client.cancel_order(\"ORD-12345\");\n\n";
+    }
+
+    // Example 2: Direct HTTP Transport Usage
+    std::cout << "--- Direct HTTP Transport Usage ---\n";
+    {
+        http_transport_config config;
+        config.host = "api.example.com";
+        config.port = 443;
+        config.use_ssl = true;
+        config.base_path = "/v1/messages";
+        config.content_type = http_content_type::json;
+        config.connect_timeout = std::chrono::seconds(10);
+        config.request_timeout = std::chrono::seconds(30);
+
+        auto transport = std::make_shared<http_transport>(config);
+
+        // Set custom headers
+        transport->set_header("X-API-Key", "your-api-key");
+        transport->set_header("Accept", "application/json");
+
+        std::cout << "HTTP transport configured.\n";
+        std::cout << "Endpoints:\n";
+        std::cout << "  POST /v1/messages/publish - Publish message\n";
+        std::cout << "  GET  /v1/messages/subscribe - Long-poll for messages\n";
+        std::cout << "  POST /v1/messages/request - Request/reply\n\n";
+    }
+
+    // Example 3: HTTP with Resilience
+    std::cout << "--- HTTP with Resilience ---\n";
+    {
+        // Create base HTTP transport
+        http_transport_config http_config;
+        http_config.host = "api.example.com";
+        http_config.port = 443;
+        http_config.use_ssl = true;
+
+        auto http = std::make_shared<http_transport>(http_config);
+
+        // Configure resilience
+        resilient_transport_config resilient_config;
+
+        // Retry configuration
+        resilient_config.retry.max_retries = 3;
+        resilient_config.retry.initial_delay = std::chrono::milliseconds(100);
+        resilient_config.retry.backoff_multiplier = 2.0;
+        resilient_config.retry.max_delay = std::chrono::seconds(10);
+
+        // Circuit breaker configuration
+        resilient_config.circuit_breaker.failure_threshold = 5;
+        resilient_config.circuit_breaker.reset_timeout = std::chrono::seconds(30);
+        resilient_config.circuit_breaker.half_open_max_calls = 3;
+
+        auto resilient = std::make_shared<resilient_transport>(
+            http, resilient_config);
+
+        // Set up monitoring
+        resilient->set_circuit_state_handler([](circuit_state state) {
+            switch (state) {
+                case circuit_state::closed:
+                    std::cout << "[Circuit] Closed - Normal operation\n";
+                    break;
+                case circuit_state::open:
+                    std::cout << "[Circuit] Open - Failing fast\n";
+                    break;
+                case circuit_state::half_open:
+                    std::cout << "[Circuit] Half-open - Testing recovery\n";
+                    break;
+            }
+        });
+
+        resilient->set_retry_handler([](std::size_t attempt,
+                                        std::chrono::milliseconds delay) {
+            std::cout << std::format("[Retry] Attempt {} after {}ms\n",
+                attempt, delay.count());
+        });
+
+        std::cout << "Resilient HTTP transport configured.\n";
+        std::cout << "Features:\n";
+        std::cout << "  - Automatic retry with exponential backoff\n";
+        std::cout << "  - Circuit breaker for fault isolation\n";
+        std::cout << "  - Configurable timeouts\n";
+    }
+
+    // Example 4: Notification Service
+    std::cout << "\n--- Notification Service ---\n";
+    {
+        // Note: This won't actually connect without valid credentials
+        std::cout << "Notification service example.\n";
+        std::cout << "In production:\n";
+        std::cout << "  notification_service notifier;\n";
+        std::cout << "  notifier.send_notification(\"user123\", ";
+        std::cout << "\"New Order\", \"Your order has been placed.\");\n";
+    }
+
+    std::cout << "\n=== Example Complete ===\n";
+    return 0;
+}

--- a/examples/network/websocket_realtime.cpp
+++ b/examples/network/websocket_realtime.cpp
@@ -1,0 +1,287 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file websocket_realtime.cpp
+ * @brief Example: Real-time messaging with WebSocket transport
+ *
+ * Demonstrates:
+ * - WebSocket-based pub/sub messaging
+ * - Topic subscriptions with wildcards
+ * - Automatic reconnection
+ * - Resilient transport wrapper
+ */
+
+#include <kcenon/messaging/adapters/websocket_transport.h>
+#include <kcenon/messaging/adapters/resilient_transport.h>
+#include <kcenon/messaging/core/message.h>
+#include <kcenon/messaging/integration/messaging_container_builder.h>
+
+#include <atomic>
+#include <chrono>
+#include <format>
+#include <iostream>
+#include <thread>
+
+using namespace kcenon::messaging;
+using namespace kcenon::messaging::adapters;
+
+namespace {
+
+/**
+ * @brief Example: Market data subscriber using WebSocket
+ */
+class market_data_subscriber {
+public:
+    explicit market_data_subscriber(const std::string& server_url)
+        : running_(false) {
+        // Configure WebSocket transport
+        websocket_transport_config config;
+        config.host = "localhost";  // Use server_url in production
+        config.port = 8080;
+        config.path = "/market-data";
+        config.auto_reconnect = true;
+        config.reconnect_delay = std::chrono::milliseconds(1000);
+        config.reconnect_backoff_multiplier = 2.0;
+        config.max_reconnect_delay = std::chrono::milliseconds(30000);
+
+        // Create WebSocket transport
+        auto ws_transport = std::make_shared<websocket_transport>(config);
+
+        // Wrap with resilient transport for additional reliability
+        resilient_transport_config resilient_config;
+        resilient_config.retry.max_retries = 3;
+        resilient_config.circuit_breaker.failure_threshold = 5;
+        resilient_config.circuit_breaker.reset_timeout = std::chrono::seconds(30);
+
+        transport_ = std::make_shared<resilient_transport>(
+            ws_transport, resilient_config);
+
+        setup_handlers();
+    }
+
+    void start() {
+        std::cout << "Connecting to market data server...\n";
+
+        auto result = transport_->connect();
+        if (result.is_err()) {
+            std::cerr << std::format("Connection failed: {}\n",
+                result.error().message);
+            return;
+        }
+
+        // Subscribe to market data topics
+        transport_->subscribe("market.*.quote");   // All quotes
+        transport_->subscribe("market.*.trade");   // All trades
+        transport_->subscribe("market.AAPL.#");    // Everything for AAPL
+
+        running_ = true;
+        std::cout << "Subscribed to market data topics\n";
+    }
+
+    void stop() {
+        running_ = false;
+        transport_->disconnect();
+        std::cout << "Disconnected from market data server\n";
+    }
+
+    void print_statistics() const {
+        auto stats = transport_->get_statistics();
+        std::cout << std::format(
+            "\n--- Statistics ---\n"
+            "Messages received: {}\n"
+            "Bytes received: {}\n"
+            "Errors: {}\n"
+            "Avg latency: {}ms\n",
+            stats.messages_received,
+            stats.bytes_received,
+            stats.errors,
+            stats.avg_latency.count()
+        );
+    }
+
+private:
+    void setup_handlers() {
+        // Handle incoming messages
+        transport_->set_message_handler([this](const message& msg) {
+            handle_market_data(msg);
+        });
+
+        // Handle state changes
+        transport_->set_state_handler([](transport_state state) {
+            switch (state) {
+                case transport_state::connected:
+                    std::cout << "[STATE] Connected\n";
+                    break;
+                case transport_state::disconnected:
+                    std::cout << "[STATE] Disconnected\n";
+                    break;
+                case transport_state::connecting:
+                    std::cout << "[STATE] Connecting...\n";
+                    break;
+                case transport_state::error:
+                    std::cout << "[STATE] Error\n";
+                    break;
+                default:
+                    break;
+            }
+        });
+
+        // Handle errors
+        transport_->set_error_handler([](const std::string& error) {
+            std::cerr << std::format("[ERROR] {}\n", error);
+        });
+    }
+
+    void handle_market_data(const message& msg) {
+        const auto& topic = msg.metadata().topic;
+        const auto& payload = msg.payload();
+
+        // Extract data from payload (using container_system)
+        auto symbol = payload.get_value<std::string>("symbol");
+        auto price = payload.get_value<double>("price");
+
+        if (symbol && price) {
+            std::cout << std::format("[{}] {} = ${:.2f}\n",
+                topic, *symbol, *price);
+        }
+
+        quotes_received_++;
+    }
+
+    std::shared_ptr<resilient_transport> transport_;
+    std::atomic<bool> running_;
+    std::atomic<uint64_t> quotes_received_{0};
+};
+
+/**
+ * @brief Example: Chat client using WebSocket
+ */
+class chat_client {
+public:
+    chat_client(const std::string& username)
+        : username_(username) {
+        websocket_transport_config config;
+        config.host = "localhost";
+        config.port = 8080;
+        config.path = "/chat";
+        config.auto_reconnect = true;
+
+        transport_ = std::make_shared<websocket_transport>(config);
+
+        transport_->set_message_handler([this](const message& msg) {
+            handle_chat_message(msg);
+        });
+    }
+
+    common::VoidResult connect() {
+        auto result = transport_->connect();
+        if (result.is_ok()) {
+            // Subscribe to chat room
+            transport_->subscribe("chat.room.*");
+            transport_->subscribe(std::format("chat.private.{}", username_));
+        }
+        return result;
+    }
+
+    common::VoidResult send_message(const std::string& room,
+                                     const std::string& text) {
+        auto msg_result = message_builder()
+            .topic(std::format("chat.room.{}", room))
+            .source(username_)
+            .type(message_type::event)
+            .build();
+
+        if (msg_result.is_err()) {
+            return common::VoidResult::err(msg_result.error());
+        }
+
+        auto& msg = msg_result.value();
+        msg.payload().set_value("text", text);
+        msg.payload().set_value("timestamp",
+            std::chrono::system_clock::now().time_since_epoch().count());
+
+        return transport_->send(msg);
+    }
+
+    void disconnect() {
+        transport_->disconnect();
+    }
+
+private:
+    void handle_chat_message(const message& msg) {
+        const auto& payload = msg.payload();
+        auto sender = payload.get_value<std::string>("sender");
+        auto text = payload.get_value<std::string>("text");
+
+        if (sender && text) {
+            std::cout << std::format("[{}]: {}\n", *sender, *text);
+        }
+    }
+
+    std::string username_;
+    std::shared_ptr<websocket_transport> transport_;
+};
+
+} // anonymous namespace
+
+int main() {
+    std::cout << "=== WebSocket Real-time Messaging Example ===\n\n";
+
+    // Example 1: Market Data Subscriber
+    std::cout << "--- Market Data Subscriber ---\n";
+    {
+        market_data_subscriber subscriber("ws://localhost:8080");
+
+        // Note: In a real application, you would connect to a real server
+        // For this example, we just demonstrate the API
+        std::cout << "Market data subscriber created.\n";
+        std::cout << "In production, call subscriber.start() to connect.\n\n";
+    }
+
+    // Example 2: Chat Client
+    std::cout << "--- Chat Client ---\n";
+    {
+        chat_client client("user123");
+
+        // Note: In a real application, you would connect to a real server
+        std::cout << "Chat client created.\n";
+        std::cout << "In production:\n";
+        std::cout << "  client.connect();\n";
+        std::cout << "  client.send_message(\"general\", \"Hello!\");\n\n";
+    }
+
+    // Example 3: Direct WebSocket usage
+    std::cout << "--- Direct WebSocket Usage ---\n";
+    {
+        websocket_transport_config config;
+        config.host = "echo.websocket.org";
+        config.port = 443;
+        config.use_ssl = true;
+        config.path = "/";
+        config.ping_interval = std::chrono::seconds(30);
+        config.auto_reconnect = true;
+
+        auto transport = std::make_shared<websocket_transport>(config);
+
+        transport->set_message_handler([](const message& msg) {
+            std::cout << std::format("Echo: {}\n", msg.metadata().topic);
+        });
+
+        transport->set_state_handler([](transport_state state) {
+            std::cout << std::format("State changed: {}\n",
+                static_cast<int>(state));
+        });
+
+        std::cout << "WebSocket transport configured.\n";
+        std::cout << "Features:\n";
+        std::cout << "  - Auto reconnection\n";
+        std::cout << "  - Ping/pong keepalive\n";
+        std::cout << "  - Topic subscriptions with wildcards\n";
+        std::cout << "  - Binary and text message support\n";
+    }
+
+    std::cout << "\n=== Example Complete ===\n";
+    return 0;
+}

--- a/include/kcenon/messaging/adapters/http_transport.h
+++ b/include/kcenon/messaging/adapters/http_transport.h
@@ -1,0 +1,156 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file http_transport.h
+ * @brief HTTP transport adapter using network_system
+ *
+ * Provides HTTP-based message transport with support for:
+ * - HTTP/1.1 protocol
+ * - GET, POST, PUT, DELETE methods
+ * - Request/response messaging
+ * - Binary and JSON serialization
+ */
+
+#pragma once
+
+#include <kcenon/messaging/adapters/transport_interface.h>
+
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+
+namespace kcenon::messaging::adapters {
+
+/**
+ * @enum http_content_type
+ * @brief HTTP content types for message serialization
+ */
+enum class http_content_type {
+    json,           // application/json
+    binary,         // application/octet-stream
+    msgpack         // application/msgpack
+};
+
+/**
+ * @struct http_transport_config
+ * @brief Configuration for HTTP transport
+ */
+struct http_transport_config : transport_config {
+    std::string base_path = "/api/messages";
+    http_content_type content_type = http_content_type::json;
+    bool use_ssl = false;
+    std::map<std::string, std::string> default_headers;
+
+    // Endpoints
+    std::string publish_endpoint = "/publish";
+    std::string subscribe_endpoint = "/subscribe";
+    std::string request_endpoint = "/request";
+};
+
+/**
+ * @class http_transport
+ * @brief HTTP transport implementation using network_system::http_client
+ *
+ * This transport is suitable for:
+ * - Request/reply messaging patterns
+ * - REST-based message APIs
+ * - Environments where WebSocket is not available
+ *
+ * Note: For real-time pub/sub, use websocket_transport instead.
+ *
+ * Usage Example:
+ * @code
+ * http_transport_config config;
+ * config.host = "api.example.com";
+ * config.port = 443;
+ * config.use_ssl = true;
+ * config.base_path = "/v1/messages";
+ *
+ * auto transport = std::make_shared<http_transport>(config);
+ * auto result = transport->connect();
+ *
+ * if (result.is_ok()) {
+ *     auto msg = message_builder()
+ *         .topic("orders.new")
+ *         .source("client-001")
+ *         .build();
+ *     transport->send(msg.value());
+ * }
+ * @endcode
+ */
+class http_transport : public transport_interface {
+public:
+    /**
+     * @brief Construct HTTP transport with configuration
+     * @param config Transport configuration
+     */
+    explicit http_transport(const http_transport_config& config);
+
+    /**
+     * @brief Destructor
+     */
+    ~http_transport() override;
+
+    // transport_interface implementation
+    common::VoidResult connect() override;
+    common::VoidResult disconnect() override;
+    bool is_connected() const override;
+    transport_state get_state() const override;
+
+    common::VoidResult send(const message& msg) override;
+    common::VoidResult send_binary(const std::vector<uint8_t>& data) override;
+
+    void set_message_handler(
+        std::function<void(const message&)> handler) override;
+    void set_binary_handler(
+        std::function<void(const std::vector<uint8_t>&)> handler) override;
+    void set_state_handler(
+        std::function<void(transport_state)> handler) override;
+    void set_error_handler(
+        std::function<void(const std::string&)> handler) override;
+
+    transport_statistics get_statistics() const override;
+    void reset_statistics() override;
+
+    // HTTP-specific methods
+
+    /**
+     * @brief Send message with HTTP POST
+     * @param endpoint Target endpoint (relative to base_path)
+     * @param msg Message to send
+     * @return Result with response message or error
+     */
+    common::Result<message> post(const std::string& endpoint, const message& msg);
+
+    /**
+     * @brief Send HTTP GET request
+     * @param endpoint Target endpoint
+     * @param query Query parameters
+     * @return Result with response message or error
+     */
+    common::Result<message> get(
+        const std::string& endpoint,
+        const std::map<std::string, std::string>& query = {});
+
+    /**
+     * @brief Set custom header for all requests
+     * @param key Header name
+     * @param value Header value
+     */
+    void set_header(const std::string& key, const std::string& value);
+
+    /**
+     * @brief Remove custom header
+     * @param key Header name
+     */
+    void remove_header(const std::string& key);
+
+private:
+    class impl;
+    std::unique_ptr<impl> pimpl_;
+};
+
+} // namespace kcenon::messaging::adapters

--- a/include/kcenon/messaging/adapters/resilient_transport.h
+++ b/include/kcenon/messaging/adapters/resilient_transport.h
@@ -1,0 +1,233 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file resilient_transport.h
+ * @brief Resilient transport wrapper with retry and circuit breaker
+ *
+ * Provides reliability features on top of any transport:
+ * - Automatic retry with exponential backoff
+ * - Circuit breaker pattern for fault isolation
+ * - Timeout management
+ * - Fallback support
+ */
+
+#pragma once
+
+#include <kcenon/messaging/adapters/transport_interface.h>
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <optional>
+
+namespace kcenon::messaging::adapters {
+
+/**
+ * @enum circuit_state
+ * @brief Circuit breaker states
+ */
+enum class circuit_state {
+    closed,     // Normal operation
+    open,       // Failing fast, not allowing requests
+    half_open   // Testing if service recovered
+};
+
+/**
+ * @struct retry_config
+ * @brief Configuration for retry behavior
+ */
+struct retry_config {
+    std::size_t max_retries = 3;
+    std::chrono::milliseconds initial_delay{100};
+    double backoff_multiplier = 2.0;
+    std::chrono::milliseconds max_delay{10000};
+    bool retry_on_timeout = true;
+};
+
+/**
+ * @struct circuit_breaker_config
+ * @brief Configuration for circuit breaker
+ */
+struct circuit_breaker_config {
+    std::size_t failure_threshold = 5;       // Failures before opening circuit
+    std::chrono::milliseconds reset_timeout{30000};  // Time before half-open
+    std::size_t half_open_max_calls = 3;     // Test calls in half-open state
+    double success_threshold = 0.5;          // Success rate to close circuit
+};
+
+/**
+ * @struct resilient_transport_config
+ * @brief Configuration for resilient transport
+ */
+struct resilient_transport_config {
+    retry_config retry;
+    circuit_breaker_config circuit_breaker;
+    std::chrono::milliseconds operation_timeout{30000};
+    bool enable_fallback = false;
+};
+
+/**
+ * @struct resilience_statistics
+ * @brief Statistics for resilience features
+ */
+struct resilience_statistics {
+    // Retry statistics
+    uint64_t total_attempts = 0;
+    uint64_t successful_first_attempts = 0;
+    uint64_t successful_retries = 0;
+    uint64_t failed_after_retries = 0;
+
+    // Circuit breaker statistics
+    uint64_t circuit_opens = 0;
+    uint64_t circuit_closes = 0;
+    uint64_t rejected_by_circuit = 0;
+    circuit_state current_circuit_state = circuit_state::closed;
+
+    // Timing
+    std::chrono::milliseconds avg_success_latency{0};
+    std::chrono::milliseconds avg_failure_latency{0};
+};
+
+/**
+ * @class resilient_transport
+ * @brief Transport wrapper providing resilience features
+ *
+ * This class wraps any transport_interface implementation and adds:
+ * - Automatic retry with configurable backoff
+ * - Circuit breaker to prevent cascade failures
+ * - Timeout management
+ * - Optional fallback when primary transport fails
+ *
+ * Usage Example:
+ * @code
+ * // Create underlying transport
+ * websocket_transport_config ws_config;
+ * ws_config.host = "primary.example.com";
+ * ws_config.port = 8080;
+ * auto primary = std::make_shared<websocket_transport>(ws_config);
+ *
+ * // Create resilient wrapper
+ * resilient_transport_config config;
+ * config.retry.max_retries = 3;
+ * config.retry.initial_delay = std::chrono::milliseconds(100);
+ * config.circuit_breaker.failure_threshold = 5;
+ * config.circuit_breaker.reset_timeout = std::chrono::seconds(30);
+ *
+ * auto resilient = std::make_shared<resilient_transport>(primary, config);
+ *
+ * // Optionally set fallback transport
+ * ws_config.host = "backup.example.com";
+ * auto backup = std::make_shared<websocket_transport>(ws_config);
+ * resilient->set_fallback(backup);
+ *
+ * // Use as normal transport
+ * resilient->connect();
+ * resilient->send(message);
+ * @endcode
+ */
+class resilient_transport : public transport_interface {
+public:
+    /**
+     * @brief Construct resilient transport wrapper
+     * @param transport Underlying transport to wrap
+     * @param config Resilience configuration
+     */
+    resilient_transport(
+        std::shared_ptr<transport_interface> transport,
+        const resilient_transport_config& config = {});
+
+    /**
+     * @brief Destructor
+     */
+    ~resilient_transport() override;
+
+    // transport_interface implementation
+    common::VoidResult connect() override;
+    common::VoidResult disconnect() override;
+    bool is_connected() const override;
+    transport_state get_state() const override;
+
+    common::VoidResult send(const message& msg) override;
+    common::VoidResult send_binary(const std::vector<uint8_t>& data) override;
+
+    void set_message_handler(
+        std::function<void(const message&)> handler) override;
+    void set_binary_handler(
+        std::function<void(const std::vector<uint8_t>&)> handler) override;
+    void set_state_handler(
+        std::function<void(transport_state)> handler) override;
+    void set_error_handler(
+        std::function<void(const std::string&)> handler) override;
+
+    transport_statistics get_statistics() const override;
+    void reset_statistics() override;
+
+    // Resilience-specific methods
+
+    /**
+     * @brief Set fallback transport for when primary fails
+     * @param fallback Fallback transport
+     */
+    void set_fallback(std::shared_ptr<transport_interface> fallback);
+
+    /**
+     * @brief Get current circuit breaker state
+     * @return Current circuit state
+     */
+    circuit_state get_circuit_state() const;
+
+    /**
+     * @brief Force circuit breaker to open state
+     */
+    void force_circuit_open();
+
+    /**
+     * @brief Force circuit breaker to closed state
+     */
+    void force_circuit_close();
+
+    /**
+     * @brief Get resilience-specific statistics
+     * @return Resilience statistics
+     */
+    resilience_statistics get_resilience_statistics() const;
+
+    /**
+     * @brief Reset resilience statistics
+     */
+    void reset_resilience_statistics();
+
+    /**
+     * @brief Update retry configuration
+     * @param config New retry configuration
+     */
+    void set_retry_config(const retry_config& config);
+
+    /**
+     * @brief Update circuit breaker configuration
+     * @param config New circuit breaker configuration
+     */
+    void set_circuit_breaker_config(const circuit_breaker_config& config);
+
+    /**
+     * @brief Set callback for circuit state changes
+     * @param handler Callback with new state
+     */
+    void set_circuit_state_handler(
+        std::function<void(circuit_state)> handler);
+
+    /**
+     * @brief Set callback for retry events
+     * @param handler Callback with attempt number and delay
+     */
+    void set_retry_handler(
+        std::function<void(std::size_t attempt, std::chrono::milliseconds delay)> handler);
+
+private:
+    class impl;
+    std::unique_ptr<impl> pimpl_;
+};
+
+} // namespace kcenon::messaging::adapters

--- a/include/kcenon/messaging/adapters/transport_interface.h
+++ b/include/kcenon/messaging/adapters/transport_interface.h
@@ -1,0 +1,151 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file transport_interface.h
+ * @brief Abstract interface for network transport adapters
+ *
+ * This interface defines the contract for network transport implementations
+ * that enable message transmission over different protocols (HTTP, WebSocket, etc.)
+ */
+
+#pragma once
+
+#include <kcenon/common/patterns/result.h>
+#include <kcenon/messaging/core/message.h>
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace kcenon::messaging::adapters {
+
+/**
+ * @enum transport_state
+ * @brief Transport connection state
+ */
+enum class transport_state {
+    disconnected,
+    connecting,
+    connected,
+    disconnecting,
+    error
+};
+
+/**
+ * @struct transport_config
+ * @brief Base configuration for transports
+ */
+struct transport_config {
+    std::string host;
+    uint16_t port = 0;
+    std::chrono::milliseconds connect_timeout{10000};
+    std::chrono::milliseconds request_timeout{30000};
+    bool auto_reconnect = false;
+    std::size_t max_retries = 3;
+    std::chrono::milliseconds retry_delay{1000};
+};
+
+/**
+ * @struct transport_statistics
+ * @brief Transport performance statistics
+ */
+struct transport_statistics {
+    uint64_t messages_sent = 0;
+    uint64_t messages_received = 0;
+    uint64_t bytes_sent = 0;
+    uint64_t bytes_received = 0;
+    uint64_t errors = 0;
+    std::chrono::milliseconds avg_latency{0};
+};
+
+/**
+ * @interface transport_interface
+ * @brief Abstract interface for network transports
+ */
+class transport_interface {
+public:
+    virtual ~transport_interface() = default;
+
+    /**
+     * @brief Connect to remote endpoint
+     * @return Result indicating success or error
+     */
+    virtual common::VoidResult connect() = 0;
+
+    /**
+     * @brief Disconnect from remote endpoint
+     * @return Result indicating success or error
+     */
+    virtual common::VoidResult disconnect() = 0;
+
+    /**
+     * @brief Check if transport is connected
+     * @return true if connected
+     */
+    virtual bool is_connected() const = 0;
+
+    /**
+     * @brief Get current transport state
+     * @return Current state
+     */
+    virtual transport_state get_state() const = 0;
+
+    /**
+     * @brief Send a message
+     * @param msg Message to send
+     * @return Result indicating success or error
+     */
+    virtual common::VoidResult send(const message& msg) = 0;
+
+    /**
+     * @brief Send binary data
+     * @param data Binary data to send
+     * @return Result indicating success or error
+     */
+    virtual common::VoidResult send_binary(const std::vector<uint8_t>& data) = 0;
+
+    /**
+     * @brief Set message received callback
+     * @param handler Callback function for received messages
+     */
+    virtual void set_message_handler(
+        std::function<void(const message&)> handler) = 0;
+
+    /**
+     * @brief Set binary data received callback
+     * @param handler Callback function for received binary data
+     */
+    virtual void set_binary_handler(
+        std::function<void(const std::vector<uint8_t>&)> handler) = 0;
+
+    /**
+     * @brief Set connection state change callback
+     * @param handler Callback for state changes
+     */
+    virtual void set_state_handler(
+        std::function<void(transport_state)> handler) = 0;
+
+    /**
+     * @brief Set error callback
+     * @param handler Callback for errors
+     */
+    virtual void set_error_handler(
+        std::function<void(const std::string&)> handler) = 0;
+
+    /**
+     * @brief Get transport statistics
+     * @return Current statistics
+     */
+    virtual transport_statistics get_statistics() const = 0;
+
+    /**
+     * @brief Reset transport statistics
+     */
+    virtual void reset_statistics() = 0;
+};
+
+} // namespace kcenon::messaging::adapters


### PR DESCRIPTION
## Summary

- Add transport interface and implementations for network_system v1.5.0 integration
- Add HTTP transport adapter for REST API messaging
- Add WebSocket transport adapter for real-time pub/sub
- Add resilient transport wrapper with retry and circuit breaker
- Add example code demonstrating usage patterns

## Changes

### New Headers (`include/kcenon/messaging/adapters/`)
- `transport_interface.h`: Abstract interface for network transports
- `http_transport.h`: HTTP/1.1 transport with JSON/binary serialization
- `websocket_transport.h`: WebSocket transport with topic subscriptions
- `resilient_transport.h`: Wrapper with retry logic and circuit breaker

### New Examples (`examples/network/`)
- `http_messaging.cpp`: HTTP-based request/reply messaging
- `websocket_realtime.cpp`: Real-time WebSocket pub/sub messaging

## Test plan

- [ ] Verify header files compile without errors
- [ ] Review transport interface design
- [ ] Test examples with mock server

## Related

This PR implements the transport layer portion of the network_system integration plan.