### PR TITLE
docs: add README.md for each messaging pattern example

### DIFF
--- a/examples/patterns/event_streaming/README.md
+++ b/examples/patterns/event_streaming/README.md
@@ -1,0 +1,169 @@
+# Event Streaming Pattern Example
+
+This example demonstrates the **Event Streaming** pattern with event sourcing, replay capabilities, and batch processing.
+
+## Overview
+
+Event Streaming enables storing events in a stream and replaying them to new subscribers. This is essential for event sourcing architectures where the current state is derived from a sequence of events.
+
+## Key Features Demonstrated
+
+- **Event Publishing**: Publish events to a stream
+- **Event Replay**: New subscribers can replay historical events
+- **Filtered Subscriptions**: Subscribe with filters (e.g., high priority only)
+- **Batch Processing**: Process events in batches for efficiency
+- **messaging_container_builder**: Type-safe event construction
+- **Message Serialization**: JSON serialization support
+
+## Quick Start
+
+```bash
+# Build the example
+cmake --build build --target example_event_streaming
+
+# Run
+./build/examples/patterns/event_streaming/example_event_streaming
+```
+
+## Code Highlights
+
+### Creating an Event Stream
+
+```cpp
+event_stream_config stream_config;
+stream_config.max_buffer_size = 100;
+stream_config.enable_replay = true;
+
+event_stream stream(bus, "events.orders", stream_config);
+```
+
+### Publishing Events with Container Builder
+
+```cpp
+auto container = messaging_container_builder()
+    .source("order-service", "stream-publisher")
+    .target("event-store", "*")
+    .message_type("order_event")
+    .add_value("order_id", std::format("order-{}", i))
+    .add_value("amount", 100.0 * i)
+    .add_value("timestamp", std::chrono::system_clock::now())
+    .optimize_for_speed()
+    .build();
+
+auto msg = message_builder()
+    .topic("events.orders")
+    .type(message_type::event)
+    .payload(container.value())
+    .build();
+
+stream.publish_event(std::move(msg.value()));
+```
+
+### Subscribing with Replay
+
+```cpp
+stream.subscribe(
+    [](const message& event) {
+        // Process event
+        return common::ok();
+    },
+    true  // Enable replay of historical events
+);
+```
+
+### Filtered Subscription
+
+```cpp
+stream.subscribe(
+    [](const message& event) { /* handler */ },
+    [](const message& event) {
+        return event.metadata().priority == message_priority::high;
+    },
+    true  // Replay with filter
+);
+```
+
+### Batch Processing
+
+```cpp
+event_batch_processor processor(
+    bus,
+    "events.batch.*",
+    [](const std::vector<message>& batch) {
+        // Process batch of events
+        return common::ok();
+    },
+    5,  // batch size
+    std::chrono::milliseconds{500}  // batch timeout
+);
+
+processor.start();
+```
+
+## Expected Output
+
+```
+=== Event Streaming Pattern Example ===
+
+1. Setting up message bus...
+Message bus started successfully
+
+2. Creating event stream...
+Event stream created for topic: events.orders
+
+3. Publishing events to stream...
+  Published event: order-1
+  Published event: order-2
+  ...
+
+4. Event stream snapshot:
+  Total events in buffer: 10
+  Retrieved 10 events
+
+5. Subscribing with replay...
+  [Replay Subscriber] Received: <event-id>
+  ...
+  Replayed 10 events
+
+6. Subscribing with filter (high priority only)...
+  [Filtered Subscriber] High priority event: <event-id>
+  Received 3 high-priority events
+
+8. Setting up batch processor...
+  [Batch Processor] Processing batch of 5 events
+  [Batch Processor] Processing batch of 5 events
+  Batches processed: 2
+```
+
+## Serialization
+
+```cpp
+message_serializer serializer;
+
+// Serialize to JSON
+auto json = serializer.to_json(container.value());
+std::cout << "JSON: " << json.value() << std::endl;
+
+// Deserialize from JSON
+auto restored = serializer.from_json(json.value());
+```
+
+## Related Patterns
+
+- [Pub/Sub](../pub_sub/) - Simple publish-subscribe
+- [Request-Reply](../request_reply/) - Synchronous RPC
+- [Message Pipeline](../message_pipeline/) - Sequential processing
+
+## API Reference
+
+| Class | Description |
+|-------|-------------|
+| `event_stream` | Stream with replay support |
+| `event_batch_processor` | Batch event processing |
+| `event_stream_config` | Stream configuration |
+| `message_serializer` | JSON/binary serialization |
+
+## See Also
+
+- [Patterns API Documentation](../../../docs/PATTERNS_API.md)
+- [API Reference](../../../docs/API_REFERENCE.md)

--- a/examples/patterns/message_pipeline/README.md
+++ b/examples/patterns/message_pipeline/README.md
@@ -1,0 +1,184 @@
+# Message Pipeline Pattern Example
+
+This example demonstrates the **Message Pipeline** (Pipes and Filters) pattern for sequential message processing with validation, transformation, and enrichment stages.
+
+## Overview
+
+The Message Pipeline pattern allows you to compose a series of processing stages that messages flow through. Each stage can validate, transform, filter, or enrich messages before passing them to the next stage.
+
+## Key Features Demonstrated
+
+- **Pipeline Builder**: Fluent API for building pipelines
+- **Validation Stages**: Validate messages before processing
+- **Filter Stages**: Conditionally pass or reject messages
+- **Transformer Stages**: Modify messages (e.g., priority boost)
+- **Enrichment Stages**: Add metadata to messages
+- **Optional Stages**: Stages that can fail without stopping the pipeline
+- **Retry Stages**: Built-in retry logic for flaky operations
+- **Pipeline Statistics**: Track success/failure rates
+
+## Quick Start
+
+```bash
+# Build the example
+cmake --build build --target example_message_pipeline
+
+# Run
+./build/examples/patterns/message_pipeline/example_message_pipeline
+```
+
+## Code Highlights
+
+### Building a Pipeline
+
+```cpp
+pipeline_builder builder(bus);
+
+auto pipeline_result = builder
+    .from("input.raw_data")
+    .to("output.processed_data")
+
+    // Validation stage
+    .add_stage("validate", [](const message& msg) -> common::Result<message> {
+        if (msg.metadata().topic.empty()) {
+            return common::make_error<message>(-1, "Invalid message");
+        }
+        return common::ok(message(msg));
+    })
+
+    // Filter stage
+    .add_filter("high_priority_filter", [](const message& msg) {
+        return msg.metadata().priority >= message_priority::normal;
+    })
+
+    // Transform stage
+    .add_transformer("boost_priority", [](const message& msg) {
+        message transformed(msg);
+        transformed.metadata().priority = message_priority::high;
+        return transformed;
+    })
+
+    // Enrichment stage
+    .add_stage("enrich", [](const message& msg) -> common::Result<message> {
+        message enriched(msg);
+        enriched.metadata().source = "pipeline-processor";
+        enriched.metadata().timestamp = std::chrono::system_clock::now();
+        return common::ok(std::move(enriched));
+    })
+
+    // Optional stage (won't fail pipeline)
+    .add_stage("log", [](const message& msg) -> common::Result<message> {
+        // Logging logic
+        return common::ok(message(msg));
+    }, true)  // Mark as optional
+
+    .build();
+```
+
+### Processing Messages
+
+```cpp
+// Manual processing
+auto result = pipeline->process(std::move(msg));
+if (result.is_ok()) {
+    auto processed = result.unwrap();
+    // Use processed message
+}
+
+// Automatic processing (subscribes to input, publishes to output)
+pipeline->start();
+```
+
+### Common Pipeline Stages
+
+```cpp
+// Validation stage
+auto validator = [](const message& msg) {
+    return !msg.metadata().id.empty();
+};
+pipeline.add_stage("validate",
+    pipeline_stages::create_validation_stage(validator));
+
+// Enrichment stage
+auto enricher = [](message& msg) {
+    msg.metadata().source = "custom-pipeline";
+};
+pipeline.add_stage("enrich",
+    pipeline_stages::create_enrichment_stage(enricher));
+
+// Retry stage for flaky operations
+auto flaky_op = [](const message& msg) -> common::Result<message> {
+    // Operation that might fail
+    return common::ok(message(msg));
+};
+pipeline.add_stage("process_with_retry",
+    pipeline_stages::create_retry_stage(flaky_op, 3));  // 3 retries
+```
+
+## Pipeline Flow
+
+```
+┌─────────────┐     ┌──────────┐     ┌──────────┐     ┌─────────┐
+│   Input     │ ──► │ Validate │ ──► │  Filter  │ ──► │Transform│
+│   Topic     │     │          │     │          │     │         │
+└─────────────┘     └──────────┘     └──────────┘     └─────────┘
+                                                            │
+┌─────────────┐     ┌──────────┐     ┌──────────┐          │
+│   Output    │ ◄── │   Log    │ ◄── │  Enrich  │ ◄────────┘
+│   Topic     │     │(optional)│     │          │
+└─────────────┘     └──────────┘     └──────────┘
+```
+
+## Expected Output
+
+```
+=== Message Pipeline Pattern Example ===
+
+1. Setting up message bus...
+Message bus started successfully
+
+2. Building message pipeline...
+Pipeline built with 5 stages:
+  1. validate
+  2. high_priority_filter
+  3. boost_priority
+  4. enrich
+  5. log
+
+3. Processing messages manually...
+
+Processing Message 1:
+  [Stage: Validate] Processing message: msg-001
+  [Stage: Validate] Message validated successfully
+  [Stage: Filter] Message passed filter
+  [Stage: Transform] Boosting message priority
+  [Stage: Enrich] Adding metadata
+  [Stage: Log] Message: msg-001 | Source: pipeline-processor | Priority: 2
+Message 1 processed successfully
+
+5. Pipeline statistics:
+  Messages processed: 5
+  Messages succeeded: 4
+  Messages failed: 1
+  Stage failures: 0
+```
+
+## Related Patterns
+
+- [Pub/Sub](../pub_sub/) - Simple publish-subscribe
+- [Request-Reply](../request_reply/) - Synchronous RPC
+- [Event Streaming](../event_streaming/) - Event sourcing with replay
+
+## API Reference
+
+| Class | Description |
+|-------|-------------|
+| `message_pipeline` | Pipeline for sequential processing |
+| `pipeline_builder` | Fluent API for building pipelines |
+| `pipeline_stages` | Factory for common stage types |
+| `pipeline_statistics` | Processing statistics |
+
+## See Also
+
+- [Patterns API Documentation](../../../docs/PATTERNS_API.md)
+- [API Reference](../../../docs/API_REFERENCE.md)

--- a/examples/patterns/pub_sub/README.md
+++ b/examples/patterns/pub_sub/README.md
@@ -1,0 +1,115 @@
+# Pub/Sub Pattern Example
+
+This example demonstrates the **Publisher-Subscriber** messaging pattern with topic-based routing and message filtering.
+
+## Overview
+
+The Pub/Sub pattern enables loosely-coupled communication where publishers send messages to topics without knowing who will receive them, and subscribers receive messages from topics they're interested in.
+
+## Key Features Demonstrated
+
+- **Topic Subscriptions**: Subscribe to topics using exact matches or wildcards
+- **Wildcard Patterns**: Use `*` (single-level) and `#` (multi-level) wildcards
+- **Message Filtering**: Apply filters to receive only specific messages
+- **messaging_container_builder**: Type-safe message construction
+- **Priority Handling**: High-priority message filtering
+
+## Quick Start
+
+```bash
+# Build the example
+cmake --build build --target example_pub_sub
+
+# Run
+./build/examples/patterns/pub_sub/example_pub_sub
+```
+
+## Code Highlights
+
+### Creating Publishers and Subscribers
+
+```cpp
+// Create subscriber
+subscriber sub(bus);
+
+// Subscribe to all user events
+sub.subscribe("events.user.*", [](const message& msg) {
+    std::cout << "Received: " << msg.metadata().topic << std::endl;
+    return common::ok();
+});
+
+// Create publisher
+publisher user_pub(bus, "events.user");
+```
+
+### Using messaging_container_builder
+
+```cpp
+auto container = messaging_container_builder()
+    .source("user-service", std::format("session_{}", i))
+    .target("subscribers", "*")
+    .message_type("user_created")
+    .add_value("user_id", std::format("USR-{:05d}", i))
+    .add_value("timestamp", std::chrono::system_clock::now())
+    .optimize_for_speed()
+    .build();
+```
+
+### Filtering by Priority
+
+```cpp
+sub.subscribe(
+    "events.#",
+    [](const message& msg) { /* handler */ },
+    [](const message& msg) {
+        return msg.metadata().priority == message_priority::high;
+    }
+);
+```
+
+## Expected Output
+
+```
+=== Pub/Sub Pattern Example ===
+
+1. Setting up message bus...
+Message bus started successfully
+
+2. Creating subscribers...
+Subscribed to user events (events.user.*)
+Subscribed to order events (events.order.*)
+Subscribed to high-priority events (events.#)
+
+3. Creating publishers...
+Publishers created
+
+4. Publishing events...
+  Published: events.user.created (event 1)
+  [User Subscriber] Received: events.user.created
+  ...
+
+6. Statistics:
+  User events received: 3
+  Order events received: 2
+  High-priority events received: 2
+```
+
+## Related Patterns
+
+- [Request-Reply](../request_reply/) - Synchronous RPC over async messaging
+- [Event Streaming](../event_streaming/) - Event sourcing with replay
+- [Message Pipeline](../message_pipeline/) - Sequential message processing
+
+## API Reference
+
+| Class | Description |
+|-------|-------------|
+| `publisher` | Publishes messages to topics |
+| `subscriber` | Subscribes to topics with optional filters |
+| `message_bus` | Central pub/sub coordinator |
+| `messaging_container_builder` | Type-safe message construction |
+
+## See Also
+
+- [Patterns API Documentation](../../../docs/PATTERNS_API.md)
+- [API Reference](../../../docs/API_REFERENCE.md)

--- a/examples/patterns/request_reply/README.md
+++ b/examples/patterns/request_reply/README.md
@@ -1,0 +1,141 @@
+# Request-Reply Pattern Example
+
+This example demonstrates the **Request-Reply** messaging pattern for synchronous RPC-style communication over asynchronous messaging infrastructure.
+
+## Overview
+
+The Request-Reply pattern enables synchronous communication where a client sends a request and waits for a response. This is useful for implementing services that need to return results to callers.
+
+## Key Features Demonstrated
+
+- **Request Client**: Send requests and wait for replies
+- **Request Server**: Handle requests and send replies
+- **Correlation IDs**: Automatic request-reply matching
+- **Timeout Handling**: Configurable request timeouts
+- **Multi-threaded**: Server and client run in separate threads
+
+## Quick Start
+
+```bash
+# Build the example
+cmake --build build --target example_request_reply
+
+# Run
+./build/examples/patterns/request_reply/example_request_reply
+```
+
+## Code Highlights
+
+### Creating a Request Server
+
+```cpp
+class CalculatorService {
+public:
+    static common::Result<message> handle_request(const message& request) {
+        // Process request
+        message reply("reply", message_type::reply);
+        reply.metadata().correlation_id = request.metadata().id;
+        reply.metadata().source = "calculator-service";
+
+        return common::ok(std::move(reply));
+    }
+};
+
+// Register handler
+request_server server(bus, "service.calculator");
+server.register_handler(CalculatorService::handle_request);
+```
+
+### Making Requests
+
+```cpp
+request_client client(bus, "service.calculator");
+
+message request("service.calculator", message_type::query);
+request.metadata().source = "client-app";
+
+auto reply_result = client.request(
+    std::move(request),
+    std::chrono::milliseconds{2000}  // timeout
+);
+
+if (reply_result.is_ok()) {
+    const auto& reply = reply_result.value();
+    // Process reply
+}
+```
+
+## Expected Output
+
+```
+=== Request-Reply Pattern Example ===
+
+1. Setting up message bus...
+Message bus started successfully
+
+2. Starting server and client...
+
+[Server Thread] Starting calculator service...
+[Server Thread] Calculator service started
+
+[Client Thread] Starting client...
+[Client Thread] Making request #1...
+  [Server] Processing request: <request-id>
+  [Server] Sending reply for: <request-id>
+[Client Thread] Received reply for request #1
+  Correlation ID: <request-id>
+
+...
+
+3. Statistics:
+  Total messages published: 6
+  Total messages processed: 6
+```
+
+## Architecture
+
+```
+┌─────────────┐     Request      ┌─────────────┐
+│   Client    │ ───────────────► │   Server    │
+│             │                  │             │
+│             │ ◄─────────────── │             │
+└─────────────┘      Reply       └─────────────┘
+                                        │
+                                        ▼
+                              ┌─────────────────┐
+                              │ Request Handler │
+                              │  (Your Logic)   │
+                              └─────────────────┘
+```
+
+## Error Handling
+
+```cpp
+auto reply_result = client.request(request, timeout);
+
+if (reply_result.is_err()) {
+    auto& error = reply_result.error();
+    // Handle timeout or other errors
+    std::cerr << "Request failed: " << error.message << std::endl;
+}
+```
+
+## Related Patterns
+
+- [Pub/Sub](../pub_sub/) - One-to-many async messaging
+- [Event Streaming](../event_streaming/) - Event sourcing with replay
+- [Message Pipeline](../message_pipeline/) - Sequential message processing
+
+## API Reference
+
+| Class | Description |
+|-------|-------------|
+| `request_client` | Sends requests and waits for replies |
+| `request_server` | Handles requests and sends replies |
+| `message_type::query` | Request message type |
+| `message_type::reply` | Reply message type |
+
+## See Also
+
+- [Patterns API Documentation](../../../docs/PATTERNS_API.md)
+- [API Reference](../../../docs/API_REFERENCE.md)


### PR DESCRIPTION
## Summary
- Add documentation for each pattern example in the examples/patterns/ directory
- Each README includes overview, quick start, code highlights, and API reference

## Changes
- `examples/patterns/pub_sub/README.md` - Pub/Sub pattern documentation
- `examples/patterns/request_reply/README.md` - Request-Reply pattern documentation
- `examples/patterns/event_streaming/README.md` - Event Streaming pattern documentation
- `examples/patterns/message_pipeline/README.md` - Message Pipeline pattern documentation

## Test plan
- [ ] Verify README files render correctly on GitHub
- [ ] Verify code examples are accurate
- [ ] Verify links to related documentation work