### PR TITLE
chore: unify version to 1.0.0 for unified_system integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 project(messaging_system
-    VERSION 2.1.0
+    VERSION 1.0.0
     DESCRIPTION "Production-ready messaging infrastructure with advanced patterns"
     LANGUAGES CXX
 )


### PR DESCRIPTION
## Summary
- Update project version from 2.1.0 to 1.0.0
- Part of unified_system version standardization effort

## Details
All subprojects in unified_system are being standardized to v1.0.0 for:
- Consistent version management across the ecosystem
- Simplified dependency version tracking
- Unified release management

## Changes
- `CMakeLists.txt`: Updated `VERSION` from 2.1.0 to 1.0.0

## Notes
This is a version number change only. No API or functionality changes.

Previous version numbers were assigned during independent development.
With unified_system integration, all projects now start unified version management from v1.0.0.

## Test plan
- [x] Build verification
- [ ] CI pipeline passes