### PR TITLE
docs: Standardize C++20 compiler requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ Publisher → Message Bus → Topic Router → Subscribers
 
 ### Prerequisites
 
-- **C++20** compiler (GCC 10+, Clang 12+, MSVC 2019+)
-- **CMake** 3.16+
+- **C++20** compiler (GCC 11+, Clang 14+, MSVC 2022+, Apple Clang 14+)
+- **CMake** 3.20+
 - **vcpkg** (for dependency management)
 
 ### Installation
@@ -551,8 +551,8 @@ cmake --build build -j
 |----------|----------|--------|
 | Ubuntu 22.04 | GCC 11+ | ✅ Tested |
 | Ubuntu 22.04 | Clang 14+ | ✅ Tested |
-| macOS 13+ | Apple Clang | ✅ Tested |
-| Windows 10+ | MSVC 2019+ | ✅ Tested |
+| macOS 13+ | Apple Clang 14+ | ✅ Tested |
+| Windows 10+ | MSVC 2022+ | ✅ Tested |
 
 ---
 


### PR DESCRIPTION
## Summary

- Update compiler requirements:
  - GCC 11+ (from 10+)
  - Clang 14+ (from 12+)
  - MSVC 2022+ (from 2019+)
  - Apple Clang 14+
- Update CMake minimum version to 3.20

## Motivation

Align all ecosystem projects with consistent C++20 requirements for better compatibility and modern language features.

## Test plan

- [ ] Verify documentation renders correctly
- [ ] Confirm CI/CD pipelines use updated compiler versions