### PR TITLE
feat(examples): add Task module example applications

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,3 +6,6 @@ add_subdirectory(patterns)
 
 # Integration examples
 add_subdirectory(integration)
+
+# Task module examples
+add_subdirectory(task)

--- a/examples/task/CMakeLists.txt
+++ b/examples/task/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Task module examples
+cmake_minimum_required(VERSION 3.16)
+
+# Helper function to create example executables
+function(add_task_example name)
+    add_executable(example_task_${name} ${name}/main.cpp)
+    target_link_libraries(example_task_${name} PRIVATE messaging_system_core)
+    target_compile_features(example_task_${name} PRIVATE cxx_std_20)
+endfunction()
+
+# Create all task examples
+add_task_example(simple_worker)
+add_task_example(priority_tasks)
+add_task_example(scheduled_tasks)
+add_task_example(chain_workflow)
+add_task_example(chord_aggregation)
+add_task_example(progress_tracking)
+add_task_example(monitoring_dashboard)

--- a/examples/task/README.md
+++ b/examples/task/README.md
@@ -1,0 +1,132 @@
+# Task Module Examples
+
+This directory contains example applications demonstrating various features of the Task module in the messaging_system.
+
+## Examples Overview
+
+| Example | Description |
+|---------|-------------|
+| [simple_worker](simple_worker/) | Basic task system usage with handler registration and task submission |
+| [priority_tasks](priority_tasks/) | Priority-based task processing and scheduling |
+| [scheduled_tasks](scheduled_tasks/) | Delayed and periodic task execution with cron expressions |
+| [chain_workflow](chain_workflow/) | Sequential task execution (ETL pipeline pattern) |
+| [chord_aggregation](chord_aggregation/) | Parallel execution with result aggregation |
+| [progress_tracking](progress_tracking/) | Real-time progress updates for long-running tasks |
+| [monitoring_dashboard](monitoring_dashboard/) | Console-based monitoring dashboard |
+
+## Building Examples
+
+From the project root:
+
+```bash
+mkdir build && cd build
+cmake .. -DBUILD_SAMPLES=ON
+cmake --build . --target example_task_simple_worker
+cmake --build . --target example_task_priority_tasks
+# ... or build all examples
+cmake --build .
+```
+
+## Running Examples
+
+After building:
+
+```bash
+./bin/example_task_simple_worker
+./bin/example_task_priority_tasks
+./bin/example_task_scheduled_tasks
+./bin/example_task_chain_workflow
+./bin/example_task_chord_aggregation
+./bin/example_task_progress_tracking
+./bin/example_task_monitoring_dashboard
+```
+
+## Key Concepts
+
+### Task System
+
+The `task_system` class is the main entry point for the Task module. It integrates:
+- Task queue for storing pending tasks
+- Worker pool for executing tasks
+- Task scheduler for periodic/delayed execution
+- Task monitor for system statistics
+
+### Handler Registration
+
+Handlers process tasks by name:
+
+```cpp
+system.register_handler("task.name", [](const task& t, task_context& ctx) {
+    // Process task
+    container_module::value_container result;
+    result.set_value("status", std::string("done"));
+    return common::ok(result);
+});
+```
+
+### Task Submission
+
+Submit tasks for immediate or delayed execution:
+
+```cpp
+// Immediate
+auto result = system.submit("task.name", payload);
+
+// Delayed
+system.submit_later(task, std::chrono::seconds(5));
+
+// Scheduled (periodic)
+system.schedule_periodic("schedule-name", task, std::chrono::minutes(1));
+```
+
+### Workflow Patterns
+
+Chain pattern (sequential):
+```cpp
+auto result = client.chain({task1, task2, task3});
+```
+
+Chord pattern (parallel with aggregation):
+```cpp
+auto result = client.chord({task1, task2, task3}, callback_task);
+```
+
+## Common Patterns
+
+### Error Handling
+
+```cpp
+auto outcome = result.get(std::chrono::seconds(10));
+if (outcome.is_ok()) {
+    auto value = outcome.unwrap();
+    // Handle success
+} else {
+    std::cerr << "Error: " << outcome.error().message << std::endl;
+}
+```
+
+### Progress Tracking
+
+```cpp
+system.register_handler("long.task", [](const task& t, task_context& ctx) {
+    for (int i = 0; i <= 100; ++i) {
+        ctx.update_progress(i / 100.0, "Step " + std::to_string(i));
+        // Do work...
+    }
+    return ok(result);
+});
+```
+
+### Cancellation Checking
+
+```cpp
+system.register_handler("cancellable", [](const task& t, task_context& ctx) {
+    while (!done) {
+        if (ctx.is_cancelled()) {
+            return error("Task cancelled");
+        }
+        // Continue work...
+    }
+    return ok(result);
+});
+```

--- a/examples/task/chain_workflow/README.md
+++ b/examples/task/chain_workflow/README.md
@@ -1,0 +1,81 @@
+# Chain Workflow Example
+
+Demonstrates sequential task execution (ETL pipeline pattern).
+
+## Features
+
+- Creating a chain of tasks that execute sequentially
+- Passing results from one task to the next
+- ETL (Extract-Transform-Load) pipeline implementation
+
+## Usage
+
+```bash
+./bin/example_task_chain_workflow
+```
+
+## Key Concepts
+
+### Chain Pattern
+
+Tasks execute sequentially, with each task receiving the previous task's result:
+
+```
+Extract --> Transform --> Load
+   │            │           │
+   └─ result ──>└─ result ─>└─ final result
+```
+
+### Creating a Chain
+
+```cpp
+std::vector<task> chain_tasks;
+chain_tasks.push_back(extract_task);
+chain_tasks.push_back(transform_task);
+chain_tasks.push_back(load_task);
+
+auto result = system.client().chain(std::move(chain_tasks));
+```
+
+### Result Passing
+
+Each task in the chain receives the previous task's result as its payload:
+
+```cpp
+system.register_handler("transform", [](const task& t, task_context& ctx) {
+    // Access result from previous task
+    auto record_count = t.payload().get_value<int>("record_count").value_or(0);
+    // ... transform data ...
+    return ok(result);
+});
+```
+
+## Use Cases
+
+- ETL data pipelines
+- Multi-step processing workflows
+- Sequential dependency execution
+
+## Expected Output
+
+```
+=== Chain Workflow Example ===
+Demonstrating ETL (Extract-Transform-Load) pipeline
+
+Task system started
+
+Building ETL chain: Extract -> Transform -> Load
+
+Executing chain...
+Waiting for chain to complete...
+
+=== Chain Completed Successfully ===
+Records loaded: 10
+Destination: data_warehouse
+Transformation: normalized
+
+=== Statistics ===
+Total tasks: 3
+Succeeded: 3
+Failed: 0
+```

--- a/examples/task/chain_workflow/main.cpp
+++ b/examples/task/chain_workflow/main.cpp
@@ -1,0 +1,184 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file main.cpp
+ * @brief Chain workflow example (sequential task execution)
+ *
+ * This example demonstrates:
+ * - Creating a chain of tasks that execute sequentially
+ * - Passing results from one task to the next
+ * - ETL (Extract-Transform-Load) pipeline pattern
+ */
+
+#include <kcenon/messaging/task/task_system.h>
+#include <chrono>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace kcenon::messaging::task;
+using namespace kcenon::common;
+
+int main() {
+    std::cout << "=== Chain Workflow Example ===" << std::endl;
+    std::cout << "Demonstrating ETL (Extract-Transform-Load) pipeline\n"
+              << std::endl;
+
+    task_system_config config;
+    config.worker.concurrency = 4;
+    task_system system(config);
+
+    // Step 1: Extract - Simulate reading data from source
+    system.register_handler("extract", [](const task& t, task_context& ctx) {
+        ctx.log_info("Starting extraction...");
+        ctx.update_progress(0.0, "Extracting data");
+
+        // Simulate extracting data from a source
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        ctx.update_progress(0.5, "Reading records");
+
+        std::vector<std::string> records = {"record1", "record2", "record3",
+                                            "record4", "record5"};
+
+        ctx.update_progress(1.0, "Extraction complete");
+        ctx.log_info("Extracted " + std::to_string(records.size()) +
+                     " records");
+
+        container_module::value_container result;
+        result.set_value("record_count", static_cast<int>(records.size()));
+        result.set_value("source", std::string("database"));
+        result.set_value("step", std::string("extract"));
+        return ok(result);
+    });
+
+    // Step 2: Transform - Process and transform the data
+    system.register_handler("transform", [](const task& t, task_context& ctx) {
+        ctx.log_info("Starting transformation...");
+        ctx.update_progress(0.0, "Transforming data");
+
+        auto payload = t.payload();
+        auto record_count = payload.get_value<int>("record_count").value_or(0);
+
+        // Simulate transformation
+        std::this_thread::sleep_for(std::chrono::milliseconds(400));
+        ctx.update_progress(0.5, "Processing records");
+
+        // Transform: double the records (as an example)
+        int transformed_count = record_count * 2;
+
+        ctx.update_progress(1.0, "Transformation complete");
+        ctx.log_info("Transformed to " + std::to_string(transformed_count) +
+                     " records");
+
+        container_module::value_container result;
+        result.set_value("record_count", transformed_count);
+        result.set_value("transformation", std::string("normalized"));
+        result.set_value("step", std::string("transform"));
+        return ok(result);
+    });
+
+    // Step 3: Load - Write data to destination
+    system.register_handler("load", [](const task& t, task_context& ctx) {
+        ctx.log_info("Starting load...");
+        ctx.update_progress(0.0, "Loading data");
+
+        auto payload = t.payload();
+        auto record_count = payload.get_value<int>("record_count").value_or(0);
+        auto transformation =
+            payload.get_string("transformation").value_or("none");
+
+        // Simulate loading to destination
+        std::this_thread::sleep_for(std::chrono::milliseconds(300));
+        ctx.update_progress(0.5, "Writing to destination");
+
+        ctx.update_progress(1.0, "Load complete");
+        ctx.log_info("Loaded " + std::to_string(record_count) +
+                     " records to destination");
+
+        container_module::value_container result;
+        result.set_value("loaded_count", record_count);
+        result.set_value("destination", std::string("data_warehouse"));
+        result.set_value("transformation_applied", transformation);
+        result.set_value("step", std::string("load"));
+        result.set_value("success", true);
+        return ok(result);
+    });
+
+    // Start the system
+    auto start_result = system.start();
+    if (start_result.is_err()) {
+        std::cerr << "Failed to start: " << start_result.error().message
+                  << std::endl;
+        return 1;
+    }
+    std::cout << "Task system started\n" << std::endl;
+
+    // Build the chain: Extract -> Transform -> Load
+    std::cout << "Building ETL chain: Extract -> Transform -> Load"
+              << std::endl;
+
+    std::vector<task> chain_tasks;
+
+    // Create extract task
+    auto extract_result = task_builder("extract").build();
+    if (extract_result.is_ok()) {
+        auto t = extract_result.unwrap();
+        container_module::value_container payload;
+        payload.set_value("source_table", std::string("users"));
+        t.set_task_payload(payload);
+        chain_tasks.push_back(std::move(t));
+    }
+
+    // Create transform task
+    auto transform_result = task_builder("transform").build();
+    if (transform_result.is_ok()) {
+        chain_tasks.push_back(transform_result.unwrap());
+    }
+
+    // Create load task
+    auto load_result = task_builder("load").build();
+    if (load_result.is_ok()) {
+        chain_tasks.push_back(load_result.unwrap());
+    }
+
+    // Execute the chain
+    std::cout << "\nExecuting chain..." << std::endl;
+    auto chain_result = system.client().chain(std::move(chain_tasks));
+
+    std::cout << "Waiting for chain to complete...\n" << std::endl;
+
+    // Wait for the final result
+    auto outcome = chain_result.get(std::chrono::seconds(30));
+
+    if (outcome.is_ok()) {
+        auto result = outcome.unwrap();
+        std::cout << "=== Chain Completed Successfully ===" << std::endl;
+
+        auto loaded_count = result.get_value<int>("loaded_count").value_or(0);
+        auto destination = result.get_string("destination").value_or("?");
+        auto transformation =
+            result.get_string("transformation_applied").value_or("?");
+
+        std::cout << "Records loaded: " << loaded_count << std::endl;
+        std::cout << "Destination: " << destination << std::endl;
+        std::cout << "Transformation: " << transformation << std::endl;
+    } else {
+        std::cerr << "Chain failed: " << outcome.error().message << std::endl;
+    }
+
+    // Display statistics
+    auto stats = system.get_statistics();
+    std::cout << "\n=== Statistics ===" << std::endl;
+    std::cout << "Total tasks: " << stats.total_tasks << std::endl;
+    std::cout << "Succeeded: " << stats.succeeded_tasks << std::endl;
+    std::cout << "Failed: " << stats.failed_tasks << std::endl;
+
+    std::cout << "\nShutting down..." << std::endl;
+    system.shutdown_graceful(std::chrono::seconds(5));
+    std::cout << "Done!" << std::endl;
+
+    return 0;
+}

--- a/examples/task/chord_aggregation/README.md
+++ b/examples/task/chord_aggregation/README.md
@@ -1,0 +1,86 @@
+# Chord Aggregation Example
+
+Demonstrates parallel execution with result aggregation.
+
+## Features
+
+- Executing multiple tasks in parallel
+- Aggregating results when all tasks complete
+- Fan-out/Fan-in pattern for data collection
+
+## Usage
+
+```bash
+./bin/example_task_chord_aggregation
+```
+
+## Key Concepts
+
+### Chord Pattern
+
+Tasks execute in parallel, then a callback aggregates all results:
+
+```
+    ┌─> Task A ─┐
+    │           │
+Input -> Task B ─┼─> Callback (aggregation)
+    │           │
+    └─> Task C ─┘
+```
+
+### Creating a Chord
+
+```cpp
+std::vector<task> parallel_tasks = {task_a, task_b, task_c};
+auto callback_task = task_builder("aggregate").build().unwrap();
+
+auto result = system.client().chord(
+    std::move(parallel_tasks),
+    std::move(callback_task)
+);
+```
+
+### Aggregation Callback
+
+The callback task receives all results and produces the final output:
+
+```cpp
+system.register_handler("aggregate", [](const task& t, task_context& ctx) {
+    // Access results from all parallel tasks
+    // Aggregate and return final result
+    return ok(aggregated_result);
+});
+```
+
+## Use Cases
+
+- Collecting data from multiple sources
+- Parallel processing with final merge
+- Distributed map-reduce operations
+
+## Expected Output
+
+```
+=== Chord Aggregation Example ===
+Collecting data from multiple sources in parallel
+
+Task system started with 4 workers
+
+Setting up chord pattern:
+  Parallel tasks: fetch from [database, cache, api, file]
+  Callback: aggregate results
+
+  Added fetch task for: database
+  Added fetch task for: cache
+  Added fetch task for: api
+  Added fetch task for: file
+
+Executing chord (parallel tasks + callback)...
+Waiting for all parallel tasks and aggregation...
+
+=== Chord Completed Successfully ===
+Sources processed: 4
+Aggregation type: sum_and_avg
+Total value: 250
+Average value: 62
+```

--- a/examples/task/chord_aggregation/main.cpp
+++ b/examples/task/chord_aggregation/main.cpp
@@ -1,0 +1,216 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file main.cpp
+ * @brief Chord pattern example (parallel execution with aggregation)
+ *
+ * This example demonstrates:
+ * - Executing multiple tasks in parallel
+ * - Aggregating results when all tasks complete
+ * - Fan-out/Fan-in pattern for data collection
+ */
+
+#include <kcenon/messaging/task/task_system.h>
+#include <chrono>
+#include <iostream>
+#include <random>
+#include <string>
+#include <thread>
+
+using namespace kcenon::messaging::task;
+using namespace kcenon::common;
+
+int main() {
+    std::cout << "=== Chord Aggregation Example ===" << std::endl;
+    std::cout << "Collecting data from multiple sources in parallel\n"
+              << std::endl;
+
+    task_system_config config;
+    config.worker.concurrency = 4;  // Multiple workers for parallel execution
+    task_system system(config);
+
+    // Random number generator for simulating varying response times
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<> delay_dist(100, 500);
+
+    // Handler for fetching data from different sources
+    system.register_handler(
+        "fetch.data", [&gen, &delay_dist](const task& t, task_context& ctx) {
+            auto payload = t.payload();
+            auto source = payload.get_string("source").value_or("unknown");
+
+            ctx.log_info("Fetching from source: " + source);
+            ctx.update_progress(0.0, "Connecting to " + source);
+
+            // Simulate varying network latency
+            auto delay = std::chrono::milliseconds(delay_dist(gen));
+            std::this_thread::sleep_for(delay);
+
+            ctx.update_progress(0.5, "Downloading data");
+
+            // Simulate data with different values from each source
+            int value = 0;
+            if (source == "database")
+                value = 100;
+            else if (source == "cache")
+                value = 50;
+            else if (source == "api")
+                value = 75;
+            else if (source == "file")
+                value = 25;
+
+            ctx.update_progress(1.0, "Fetch complete");
+            ctx.log_info(source + " returned value: " + std::to_string(value));
+
+            container_module::value_container result;
+            result.set_value("source", source);
+            result.set_value("value", value);
+            result.set_value("latency_ms", static_cast<int>(delay.count()));
+            return ok(result);
+        });
+
+    // Aggregation handler - called when all parallel tasks complete
+    system.register_handler(
+        "aggregate", [](const task& t, task_context& ctx) {
+            ctx.log_info("Aggregating results from all sources");
+            ctx.update_progress(0.0, "Starting aggregation");
+
+            auto payload = t.payload();
+
+            // In a real implementation, the chord pattern would pass
+            // all results to this callback. For this example, we simulate.
+            int total = 100 + 50 + 75 + 25;  // Sum of all source values
+            int avg = total / 4;
+
+            ctx.update_progress(0.5, "Calculating statistics");
+
+            ctx.update_progress(1.0, "Aggregation complete");
+            ctx.log_info("Aggregated total: " + std::to_string(total) +
+                         ", average: " + std::to_string(avg));
+
+            container_module::value_container result;
+            result.set_value("total", total);
+            result.set_value("average", avg);
+            result.set_value("source_count", 4);
+            result.set_value("aggregation_type", std::string("sum_and_avg"));
+            return ok(result);
+        });
+
+    // Start the system
+    auto start_result = system.start();
+    if (start_result.is_err()) {
+        std::cerr << "Failed to start: " << start_result.error().message
+                  << std::endl;
+        return 1;
+    }
+    std::cout << "Task system started with " << system.total_workers()
+              << " workers\n"
+              << std::endl;
+
+    // Build the chord: Parallel tasks with aggregation callback
+    std::cout << "Setting up chord pattern:" << std::endl;
+    std::cout << "  Parallel tasks: fetch from [database, cache, api, file]"
+              << std::endl;
+    std::cout << "  Callback: aggregate results\n" << std::endl;
+
+    std::vector<task> parallel_tasks;
+    std::vector<std::string> sources = {"database", "cache", "api", "file"};
+
+    for (const auto& source : sources) {
+        auto task_result = task_builder("fetch.data").build();
+        if (task_result.is_ok()) {
+            auto t = task_result.unwrap();
+            container_module::value_container payload;
+            payload.set_value("source", source);
+            t.set_task_payload(payload);
+            parallel_tasks.push_back(std::move(t));
+            std::cout << "  Added fetch task for: " << source << std::endl;
+        }
+    }
+
+    // Create the aggregation callback task
+    auto callback_result = task_builder("aggregate").build();
+    if (callback_result.is_err()) {
+        std::cerr << "Failed to create callback task" << std::endl;
+        return 1;
+    }
+    auto callback_task = callback_result.unwrap();
+
+    // Execute chord pattern
+    std::cout << "\nExecuting chord (parallel tasks + callback)..." << std::endl;
+    auto chord_result =
+        system.client().chord(std::move(parallel_tasks), std::move(callback_task));
+
+    std::cout << "Waiting for all parallel tasks and aggregation...\n"
+              << std::endl;
+
+    // Wait for the aggregated result
+    auto outcome = chord_result.get(std::chrono::seconds(30));
+
+    if (outcome.is_ok()) {
+        auto result = outcome.unwrap();
+        std::cout << "=== Chord Completed Successfully ===" << std::endl;
+
+        auto total = result.get_value<int>("total").value_or(0);
+        auto average = result.get_value<int>("average").value_or(0);
+        auto source_count = result.get_value<int>("source_count").value_or(0);
+        auto agg_type =
+            result.get_string("aggregation_type").value_or("unknown");
+
+        std::cout << "Sources processed: " << source_count << std::endl;
+        std::cout << "Aggregation type: " << agg_type << std::endl;
+        std::cout << "Total value: " << total << std::endl;
+        std::cout << "Average value: " << average << std::endl;
+    } else {
+        std::cerr << "Chord failed: " << outcome.error().message << std::endl;
+    }
+
+    // Also demonstrate individual parallel tasks without callback
+    std::cout << "\n--- Bonus: Simple parallel execution ---" << std::endl;
+
+    std::vector<async_result> individual_results;
+    for (const auto& source : sources) {
+        auto task_result = task_builder("fetch.data").build();
+        if (task_result.is_ok()) {
+            auto t = task_result.unwrap();
+            container_module::value_container payload;
+            payload.set_value("source", source);
+            t.set_task_payload(payload);
+            individual_results.push_back(system.submit(std::move(t)));
+        }
+    }
+
+    std::cout << "Submitted " << individual_results.size()
+              << " parallel tasks" << std::endl;
+
+    // Collect all results
+    int parallel_total = 0;
+    for (size_t i = 0; i < individual_results.size(); ++i) {
+        auto result = individual_results[i].get(std::chrono::seconds(10));
+        if (result.is_ok()) {
+            auto value = result.unwrap();
+            auto source = value.get_string("source").value_or("?");
+            auto val = value.get_value<int>("value").value_or(0);
+            auto latency = value.get_value<int>("latency_ms").value_or(0);
+            parallel_total += val;
+            std::cout << "  " << source << ": value=" << val
+                      << ", latency=" << latency << "ms" << std::endl;
+        }
+    }
+    std::cout << "  Total: " << parallel_total << std::endl;
+
+    // Display statistics
+    auto stats = system.get_statistics();
+    std::cout << "\n=== Statistics ===" << std::endl;
+    std::cout << "Total tasks: " << stats.total_tasks << std::endl;
+    std::cout << "Succeeded: " << stats.succeeded_tasks << std::endl;
+
+    std::cout << "\nShutting down..." << std::endl;
+    system.shutdown_graceful(std::chrono::seconds(5));
+    std::cout << "Done!" << std::endl;
+
+    return 0;
+}

--- a/examples/task/monitoring_dashboard/README.md
+++ b/examples/task/monitoring_dashboard/README.md
@@ -1,0 +1,84 @@
+# Monitoring Dashboard Example
+
+Demonstrates console-based monitoring visualization.
+
+## Features
+
+- Using `task_monitor` for system status
+- Displaying queue and worker statistics
+- Real-time dashboard updates
+- Tracking task events and failures
+
+## Usage
+
+```bash
+./bin/example_task_monitoring_dashboard
+```
+
+## Key Concepts
+
+### Accessing Monitor
+
+```cpp
+task_system_config config;
+config.enable_monitoring = true;
+task_system system(config);
+
+// Access monitor
+auto monitor = system.monitor();
+auto events = monitor->recent_events(10);
+```
+
+### Worker Statistics
+
+```cpp
+auto stats = system.get_statistics();
+std::cout << "Total tasks: " << stats.total_tasks << std::endl;
+std::cout << "Succeeded: " << stats.succeeded_tasks << std::endl;
+std::cout << "Failed: " << stats.failed_tasks << std::endl;
+```
+
+### Queue Status
+
+```cpp
+std::cout << "Pending: " << system.pending_count() << std::endl;
+std::cout << "Active workers: " << system.active_workers() << std::endl;
+```
+
+## Dashboard Display
+
+The example shows a live-updating dashboard:
+
+```
+╔══════════════════════════════════════════════════════════╗
+║           Task System Monitoring Dashboard               ║
+║                   12:00:00                               ║
+╚══════════════════════════════════════════════════════════╝
+
+┌─ Worker Pool Status ──────────────────────────────────────┐
+│ Total Workers:      4                                     │
+│ Active Workers:     2                                     │
+│ Idle Workers:       2                                     │
+└───────────────────────────────────────────────────────────┘
+
+┌─ Queue Status ────────────────────────────────────────────┐
+│ Pending Tasks:      5                                     │
+└───────────────────────────────────────────────────────────┘
+
+┌─ Task Statistics ─────────────────────────────────────────┐
+│ Total Submitted:       50                                 │
+│ Succeeded:             45                                 │
+│ Failed:                 5                                 │
+│ Retried:                3                                 │
+│ Success Rate:        90.0%                                │
+└───────────────────────────────────────────────────────────┘
+
+Press Ctrl+C to exit
+```
+
+## Use Cases
+
+- Development and debugging
+- System health monitoring
+- Performance analysis
+- Capacity planning

--- a/examples/task/monitoring_dashboard/main.cpp
+++ b/examples/task/monitoring_dashboard/main.cpp
@@ -1,0 +1,257 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file main.cpp
+ * @brief Monitoring dashboard example with console-based visualization
+ *
+ * This example demonstrates:
+ * - Using task_monitor for system status
+ * - Displaying queue and worker statistics
+ * - Tracking task events and failures
+ */
+
+#include <kcenon/messaging/task/task_system.h>
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <thread>
+
+using namespace kcenon::messaging::task;
+using namespace kcenon::common;
+
+// Clear screen (works on most terminals)
+void clear_screen() {
+#ifdef _WIN32
+    system("cls");
+#else
+    std::cout << "\033[2J\033[H";
+#endif
+}
+
+// Get current time string
+std::string current_time() {
+    auto now = std::chrono::system_clock::now();
+    auto time_t = std::chrono::system_clock::to_time_t(now);
+    std::stringstream ss;
+    ss << std::put_time(std::localtime(&time_t), "%H:%M:%S");
+    return ss.str();
+}
+
+// Display a horizontal bar
+void print_bar(int width = 60) {
+    std::cout << std::string(width, '-') << std::endl;
+}
+
+// Display dashboard
+void display_dashboard(task_system& system) {
+    clear_screen();
+
+    std::cout << "╔══════════════════════════════════════════════════════════╗"
+              << std::endl;
+    std::cout << "║           Task System Monitoring Dashboard               ║"
+              << std::endl;
+    std::cout << "║                   " << current_time()
+              << "                             ║" << std::endl;
+    std::cout << "╚══════════════════════════════════════════════════════════╝"
+              << std::endl;
+    std::cout << std::endl;
+
+    // Worker statistics
+    auto stats = system.get_statistics();
+    std::cout << "┌─ Worker Pool Status ──────────────────────────────────────┐"
+              << std::endl;
+    std::cout << "│ Total Workers:  " << std::setw(5) << system.total_workers()
+              << "                                       │" << std::endl;
+    std::cout << "│ Active Workers: " << std::setw(5) << system.active_workers()
+              << "                                       │" << std::endl;
+    std::cout << "│ Idle Workers:   " << std::setw(5)
+              << (system.total_workers() - system.active_workers())
+              << "                                       │" << std::endl;
+    std::cout << "└────────────────────────────────────────────────────────────┘"
+              << std::endl;
+    std::cout << std::endl;
+
+    // Queue statistics
+    std::cout << "┌─ Queue Status ────────────────────────────────────────────┐"
+              << std::endl;
+    std::cout << "│ Pending Tasks:  " << std::setw(5) << system.pending_count()
+              << "                                       │" << std::endl;
+    std::cout << "└────────────────────────────────────────────────────────────┘"
+              << std::endl;
+    std::cout << std::endl;
+
+    // Task statistics
+    std::cout << "┌─ Task Statistics ─────────────────────────────────────────┐"
+              << std::endl;
+    std::cout << "│ Total Submitted:  " << std::setw(8) << stats.total_tasks
+              << "                                │" << std::endl;
+    std::cout << "│ Succeeded:        " << std::setw(8) << stats.succeeded_tasks
+              << "                                │" << std::endl;
+    std::cout << "│ Failed:           " << std::setw(8) << stats.failed_tasks
+              << "                                │" << std::endl;
+    std::cout << "│ Retried:          " << std::setw(8) << stats.retried_tasks
+              << "                                │" << std::endl;
+
+    // Calculate success rate
+    double success_rate = 0.0;
+    if (stats.total_tasks > 0) {
+        success_rate = static_cast<double>(stats.succeeded_tasks) /
+                       stats.total_tasks * 100.0;
+    }
+    std::cout << "│ Success Rate:     " << std::fixed << std::setprecision(1)
+              << std::setw(7) << success_rate
+              << "%                               │" << std::endl;
+    std::cout << "└────────────────────────────────────────────────────────────┘"
+              << std::endl;
+    std::cout << std::endl;
+
+    // Monitor events (if available)
+    if (system.monitor()) {
+        auto monitor = system.monitor();
+        auto events = monitor->recent_events(5);
+
+        std::cout
+            << "┌─ Recent Events ────────────────────────────────────────────┐"
+            << std::endl;
+        if (events.empty()) {
+            std::cout
+                << "│ No recent events                                           │"
+                << std::endl;
+        } else {
+            for (const auto& event : events) {
+                std::stringstream ss;
+                ss << "│ " << std::left << std::setw(58)
+                   << event.description.substr(0, 56) << "│";
+                std::cout << ss.str() << std::endl;
+            }
+        }
+        std::cout
+            << "└────────────────────────────────────────────────────────────┘"
+            << std::endl;
+    }
+
+    std::cout << std::endl;
+    std::cout << "Press Ctrl+C to exit" << std::endl;
+}
+
+int main() {
+    std::cout << "=== Monitoring Dashboard Example ===" << std::endl;
+    std::cout << "Starting task system..." << std::endl;
+
+    // Configure with monitoring enabled
+    task_system_config config;
+    config.worker.concurrency = 4;
+    config.enable_monitoring = true;
+    config.enable_scheduler = true;
+    task_system system(config);
+
+    // Register various handlers
+    system.register_handler("quick.task", [](const task& t, task_context& ctx) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        container_module::value_container result;
+        result.set_value("status", std::string("done"));
+        return ok(result);
+    });
+
+    system.register_handler(
+        "medium.task", [](const task& t, task_context& ctx) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+            container_module::value_container result;
+            result.set_value("status", std::string("done"));
+            return ok(result);
+        });
+
+    system.register_handler("slow.task", [](const task& t, task_context& ctx) {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+        container_module::value_container result;
+        result.set_value("status", std::string("done"));
+        return ok(result);
+    });
+
+    // Handler that sometimes fails
+    static std::atomic<int> fail_counter{0};
+    system.register_handler(
+        "flaky.task", [](const task& t, task_context& ctx) {
+            int count = ++fail_counter;
+            if (count % 3 == 0) {
+                return Result<container_module::value_container>(
+                    error_info{-1, "Random failure"});
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+            container_module::value_container result;
+            result.set_value("status", std::string("done"));
+            return ok(result);
+        });
+
+    // Start the system
+    auto start_result = system.start();
+    if (start_result.is_err()) {
+        std::cerr << "Failed to start: " << start_result.error().message
+                  << std::endl;
+        return 1;
+    }
+
+    // Background thread to generate tasks
+    std::atomic<bool> running{true};
+    std::thread task_generator([&system, &running]() {
+        std::vector<std::string> task_types = {"quick.task", "medium.task",
+                                               "slow.task", "flaky.task"};
+        int index = 0;
+
+        while (running) {
+            std::string task_type = task_types[index % task_types.size()];
+
+            auto task_result = task_builder(task_type).build();
+            if (task_result.is_ok()) {
+                system.submit(task_result.unwrap());
+            }
+
+            index++;
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        }
+    });
+
+    // Main loop - display dashboard
+    std::cout << "\nStarting dashboard in 2 seconds..." << std::endl;
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    // Run for 15 seconds
+    auto start_time = std::chrono::steady_clock::now();
+    auto duration = std::chrono::seconds(15);
+
+    while (std::chrono::steady_clock::now() - start_time < duration) {
+        display_dashboard(system);
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    }
+
+    // Stop task generation
+    running = false;
+    task_generator.join();
+
+    // Final display
+    clear_screen();
+    std::cout << "=== Final Statistics ===" << std::endl;
+
+    auto stats = system.get_statistics();
+    std::cout << "Total tasks processed: " << stats.total_tasks << std::endl;
+    std::cout << "Succeeded: " << stats.succeeded_tasks << std::endl;
+    std::cout << "Failed: " << stats.failed_tasks << std::endl;
+    std::cout << "Retried: " << stats.retried_tasks << std::endl;
+
+    if (stats.total_tasks > 0) {
+        double success_rate = static_cast<double>(stats.succeeded_tasks) /
+                              stats.total_tasks * 100.0;
+        std::cout << "Success rate: " << std::fixed << std::setprecision(1)
+                  << success_rate << "%" << std::endl;
+    }
+
+    std::cout << "\nShutting down..." << std::endl;
+    system.shutdown_graceful(std::chrono::seconds(5));
+    std::cout << "Done!" << std::endl;
+
+    return 0;
+}

--- a/examples/task/priority_tasks/README.md
+++ b/examples/task/priority_tasks/README.md
@@ -1,0 +1,64 @@
+# Priority Tasks Example
+
+Demonstrates priority-based task processing.
+
+## Features
+
+- Creating tasks with different priority levels
+- Observing priority-based processing order
+- Using `task_builder` to configure task priorities
+
+## Usage
+
+```bash
+./bin/example_task_priority_tasks
+```
+
+## Key Concepts
+
+### Priority Levels
+
+Lower numbers indicate higher priority:
+- Priority 1: High (processed first)
+- Priority 5: Medium
+- Priority 10: Low (processed last)
+
+### Setting Priority
+
+```cpp
+auto task_result = task_builder("process")
+    .priority(1)  // High priority
+    .build();
+```
+
+## Expected Behavior
+
+When multiple tasks are queued:
+1. High priority tasks (priority 1) are processed first
+2. Medium priority tasks (priority 5) are processed next
+3. Low priority tasks (priority 10) are processed last
+
+Note: The first task may start immediately before all tasks are queued, so the exact order may vary slightly.
+
+## Expected Output
+
+```
+=== Priority Tasks Example ===
+Task system started
+
+Submitting tasks with different priorities...
+(Lower number = higher priority)
+
+  Submitted: Low-0 (priority 10)
+  Submitted: Low-1 (priority 10)
+  Submitted: Low-2 (priority 10)
+  Submitted: Medium-0 (priority 5)
+  Submitted: Medium-1 (priority 5)
+  Submitted: High-0 (priority 1)
+
+Processing order (observe priority handling):
+  Completed: High-0 (priority 1)
+  Completed: Medium-0 (priority 5)
+  Completed: Medium-1 (priority 5)
+  ...
+```

--- a/examples/task/priority_tasks/main.cpp
+++ b/examples/task/priority_tasks/main.cpp
@@ -1,0 +1,148 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file main.cpp
+ * @brief Priority-based task processing example
+ *
+ * This example demonstrates:
+ * - Creating tasks with different priorities
+ * - Observing priority-based processing order
+ * - Using multiple task queues
+ */
+
+#include <kcenon/messaging/task/task_system.h>
+#include <chrono>
+#include <iostream>
+#include <string>
+#include <thread>
+
+using namespace kcenon::messaging::task;
+using namespace kcenon::common;
+
+int main() {
+    std::cout << "=== Priority Tasks Example ===" << std::endl;
+
+    // Configure system with a single worker to demonstrate ordering
+    task_system_config config;
+    config.worker.concurrency = 1;  // Single worker to show priority ordering
+    task_system system(config);
+
+    // Register a handler that takes some time to process
+    system.register_handler(
+        "process", [](const task& t, task_context& ctx) {
+            auto payload = t.payload();
+            auto name = payload.get_string("name").value_or("unknown");
+            auto priority = payload.get_value<int>("priority").value_or(0);
+
+            ctx.log_info("Processing: " + name + " (priority: " +
+                         std::to_string(priority) + ")");
+
+            // Simulate work
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+            container_module::value_container result;
+            result.set_value("processed", name);
+            result.set_value("priority", priority);
+            return ok(result);
+        });
+
+    auto start_result = system.start();
+    if (start_result.is_err()) {
+        std::cerr << "Failed to start: " << start_result.error().message
+                  << std::endl;
+        return 1;
+    }
+
+    std::cout << "\nSubmitting tasks with different priorities..." << std::endl;
+    std::cout << "(Lower number = higher priority)\n" << std::endl;
+
+    std::vector<async_result> results;
+
+    // Submit tasks in reverse priority order to demonstrate priority scheduling
+    // Note: The first task may start immediately before the rest are queued
+
+    // Submit low priority tasks first
+    for (int i = 0; i < 3; ++i) {
+        auto task_result =
+            task_builder("process")
+                .priority(10)  // Low priority
+                .build();
+
+        if (task_result.is_ok()) {
+            auto t = task_result.unwrap();
+            container_module::value_container payload;
+            payload.set_value("name", std::string("Low-" + std::to_string(i)));
+            payload.set_value("priority", 10);
+            t.set_task_payload(payload);
+
+            results.push_back(system.submit(std::move(t)));
+            std::cout << "  Submitted: Low-" << i << " (priority 10)"
+                      << std::endl;
+        }
+    }
+
+    // Submit medium priority tasks
+    for (int i = 0; i < 2; ++i) {
+        auto task_result =
+            task_builder("process")
+                .priority(5)  // Medium priority
+                .build();
+
+        if (task_result.is_ok()) {
+            auto t = task_result.unwrap();
+            container_module::value_container payload;
+            payload.set_value("name",
+                              std::string("Medium-" + std::to_string(i)));
+            payload.set_value("priority", 5);
+            t.set_task_payload(payload);
+
+            results.push_back(system.submit(std::move(t)));
+            std::cout << "  Submitted: Medium-" << i << " (priority 5)"
+                      << std::endl;
+        }
+    }
+
+    // Submit high priority task
+    {
+        auto task_result =
+            task_builder("process")
+                .priority(1)  // High priority
+                .build();
+
+        if (task_result.is_ok()) {
+            auto t = task_result.unwrap();
+            container_module::value_container payload;
+            payload.set_value("name", std::string("High-0"));
+            payload.set_value("priority", 1);
+            t.set_task_payload(payload);
+
+            results.push_back(system.submit(std::move(t)));
+            std::cout << "  Submitted: High-0 (priority 1)" << std::endl;
+        }
+    }
+
+    std::cout << "\nProcessing order (observe priority handling):" << std::endl;
+
+    // Collect results in order of completion
+    for (size_t i = 0; i < results.size(); ++i) {
+        auto outcome = results[i].get(std::chrono::seconds(30));
+        if (outcome.is_ok()) {
+            auto value = outcome.unwrap();
+            auto name = value.get_string("processed").value_or("?");
+            auto priority = value.get_value<int>("priority").value_or(0);
+            std::cout << "  Completed: " << name << " (priority " << priority
+                      << ")" << std::endl;
+        }
+    }
+
+    // Display statistics
+    auto stats = system.get_statistics();
+    std::cout << "\n=== Statistics ===" << std::endl;
+    std::cout << "Total processed: " << stats.succeeded_tasks << std::endl;
+
+    system.shutdown_graceful(std::chrono::seconds(5));
+    std::cout << "\nDone!" << std::endl;
+    return 0;
+}

--- a/examples/task/progress_tracking/README.md
+++ b/examples/task/progress_tracking/README.md
@@ -1,0 +1,85 @@
+# Progress Tracking Example
+
+Demonstrates real-time progress updates for long-running tasks.
+
+## Features
+
+- Updating task progress with `update_progress()`
+- Polling for progress from the client side
+- Displaying progress bars in the console
+- Checkpoint save/restore for resumable tasks
+
+## Usage
+
+```bash
+./bin/example_task_progress_tracking
+```
+
+## Key Concepts
+
+### Updating Progress
+
+From within a handler:
+
+```cpp
+system.register_handler("long.task", [](const task& t, task_context& ctx) {
+    for (int step = 0; step <= 100; ++step) {
+        double progress = step / 100.0;
+        ctx.update_progress(progress, "Step " + std::to_string(step));
+        // Do work...
+    }
+    return ok(result);
+});
+```
+
+### Reading Progress
+
+From the client side:
+
+```cpp
+auto result = system.submit("long.task", payload);
+
+while (result.status() != task_state::succeeded) {
+    double progress = result.progress();
+    std::string message = result.progress_message();
+    display_progress_bar(progress, message);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+}
+```
+
+### Checkpoints
+
+Save and restore progress for resumable tasks:
+
+```cpp
+// Save checkpoint
+container_module::value_container state;
+state.set_value("step", current_step);
+ctx.save_checkpoint(state);
+
+// Load checkpoint (on retry)
+auto checkpoint = ctx.load_checkpoint();
+int start_step = checkpoint.get_value<int>("step").value_or(0);
+```
+
+## Expected Output
+
+```
+=== Progress Tracking Example ===
+Task system started
+
+=== Processing File ===
+Submitted task: abc123...
+Tracking progress:
+
+[========================================>] 100.0% - Processing step 15/15
+
+File processed successfully!
+  Steps completed: 15
+
+=== Multi-Phase Task ===
+[========================================>] 100.0% - All phases complete
+
+Multi-phase task completed!
+  Phases completed: 5
+```

--- a/examples/task/progress_tracking/main.cpp
+++ b/examples/task/progress_tracking/main.cpp
@@ -1,0 +1,229 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file main.cpp
+ * @brief Progress tracking example for long-running tasks
+ *
+ * This example demonstrates:
+ * - Updating task progress with update_progress()
+ * - Polling for progress from the client side
+ * - Displaying progress bars in the console
+ */
+
+#include <kcenon/messaging/task/task_system.h>
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <thread>
+
+using namespace kcenon::messaging::task;
+using namespace kcenon::common;
+
+// Helper function to display a progress bar
+void display_progress_bar(double progress, const std::string& message = "") {
+    const int bar_width = 40;
+    int filled = static_cast<int>(progress * bar_width);
+
+    std::cout << "\r[";
+    for (int i = 0; i < bar_width; ++i) {
+        if (i < filled)
+            std::cout << "=";
+        else if (i == filled)
+            std::cout << ">";
+        else
+            std::cout << " ";
+    }
+    std::cout << "] " << std::fixed << std::setprecision(1) << (progress * 100)
+              << "%";
+    if (!message.empty()) {
+        std::cout << " - " << message;
+    }
+    std::cout << std::flush;
+}
+
+int main() {
+    std::cout << "=== Progress Tracking Example ===" << std::endl;
+
+    task_system_config config;
+    config.worker.concurrency = 2;
+    task_system system(config);
+
+    // Handler for a long-running file processing task
+    system.register_handler(
+        "process.file", [](const task& t, task_context& ctx) {
+            auto payload = t.payload();
+            auto filename = payload.get_string("filename").value_or("data.csv");
+            auto total_steps =
+                payload.get_value<int>("steps").value_or(10);
+
+            ctx.log_info("Starting to process: " + filename);
+
+            // Simulate processing with progress updates
+            for (int step = 0; step <= total_steps; ++step) {
+                // Check for cancellation
+                if (ctx.is_cancelled()) {
+                    ctx.log_warning("Task cancelled at step " +
+                                    std::to_string(step));
+                    return Result<container_module::value_container>(
+                        error_info{-1, "Task was cancelled"});
+                }
+
+                // Update progress
+                double progress = static_cast<double>(step) / total_steps;
+                std::string message = "Processing step " + std::to_string(step) +
+                                      "/" + std::to_string(total_steps);
+                ctx.update_progress(progress, message);
+
+                // Simulate work
+                std::this_thread::sleep_for(std::chrono::milliseconds(200));
+            }
+
+            ctx.log_info("Processing complete for: " + filename);
+
+            container_module::value_container result;
+            result.set_value("filename", filename);
+            result.set_value("steps_completed", total_steps);
+            result.set_value("status", std::string("completed"));
+            return ok(result);
+        });
+
+    // Handler for multi-phase task with checkpoints
+    system.register_handler(
+        "multi.phase", [](const task& t, task_context& ctx) {
+            // Check if we have a checkpoint from a previous attempt
+            auto checkpoint = ctx.load_checkpoint();
+            int start_phase = 1;
+
+            auto saved_phase = checkpoint.get_value<int>("phase");
+            if (saved_phase && ctx.attempt_number() > 1) {
+                start_phase = saved_phase.value();
+                ctx.log_info("Resuming from phase " +
+                             std::to_string(start_phase));
+            }
+
+            const int total_phases = 5;
+
+            for (int phase = start_phase; phase <= total_phases; ++phase) {
+                double progress =
+                    static_cast<double>(phase - 1) / total_phases;
+                ctx.update_progress(progress,
+                                    "Phase " + std::to_string(phase) + "/" +
+                                        std::to_string(total_phases));
+
+                // Simulate phase work
+                std::this_thread::sleep_for(std::chrono::milliseconds(300));
+
+                // Save checkpoint after each phase
+                container_module::value_container state;
+                state.set_value("phase", phase + 1);
+                ctx.save_checkpoint(state);
+
+                ctx.log_info("Completed phase " + std::to_string(phase));
+            }
+
+            ctx.update_progress(1.0, "All phases complete");
+
+            container_module::value_container result;
+            result.set_value("phases_completed", total_phases);
+            return ok(result);
+        });
+
+    // Start the system
+    auto start_result = system.start();
+    if (start_result.is_err()) {
+        std::cerr << "Failed to start: " << start_result.error().message
+                  << std::endl;
+        return 1;
+    }
+    std::cout << "Task system started\n" << std::endl;
+
+    // Submit a file processing task
+    std::cout << "=== Processing File ===" << std::endl;
+    container_module::value_container payload;
+    payload.set_value("filename", std::string("large_dataset.csv"));
+    payload.set_value("steps", 15);
+
+    auto file_result = system.submit("process.file", payload);
+    std::string task_id = file_result.task_id();
+    std::cout << "Submitted task: " << task_id << std::endl;
+
+    // Poll for progress
+    std::cout << "Tracking progress:\n" << std::endl;
+
+    while (true) {
+        auto status = file_result.status();
+
+        // Get progress from the task
+        double progress = file_result.progress();
+        auto message = file_result.progress_message();
+
+        display_progress_bar(progress, message);
+
+        if (status == task_state::succeeded || status == task_state::failed ||
+            status == task_state::cancelled) {
+            std::cout << std::endl;  // New line after progress bar
+            break;
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    // Get the final result
+    auto file_outcome = file_result.get(std::chrono::seconds(1));
+    if (file_outcome.is_ok()) {
+        auto value = file_outcome.unwrap();
+        std::cout << "\nFile processed successfully!" << std::endl;
+        std::cout << "  Steps completed: "
+                  << value.get_value<int>("steps_completed").value_or(0)
+                  << std::endl;
+    } else {
+        std::cerr << "\nFile processing failed: "
+                  << file_outcome.error().message << std::endl;
+    }
+
+    // Submit multi-phase task
+    std::cout << "\n=== Multi-Phase Task ===" << std::endl;
+    auto phase_result = system.submit("multi.phase", {});
+    std::cout << "Submitted multi-phase task\n" << std::endl;
+
+    // Track multi-phase progress
+    while (true) {
+        auto status = phase_result.status();
+        double progress = phase_result.progress();
+        auto message = phase_result.progress_message();
+
+        display_progress_bar(progress, message);
+
+        if (status == task_state::succeeded || status == task_state::failed ||
+            status == task_state::cancelled) {
+            std::cout << std::endl;
+            break;
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    auto phase_outcome = phase_result.get(std::chrono::seconds(1));
+    if (phase_outcome.is_ok()) {
+        auto value = phase_outcome.unwrap();
+        std::cout << "\nMulti-phase task completed!" << std::endl;
+        std::cout << "  Phases completed: "
+                  << value.get_value<int>("phases_completed").value_or(0)
+                  << std::endl;
+    }
+
+    // Display statistics
+    auto stats = system.get_statistics();
+    std::cout << "\n=== Statistics ===" << std::endl;
+    std::cout << "Total tasks: " << stats.total_tasks << std::endl;
+    std::cout << "Succeeded: " << stats.succeeded_tasks << std::endl;
+
+    std::cout << "\nShutting down..." << std::endl;
+    system.shutdown_graceful(std::chrono::seconds(5));
+    std::cout << "Done!" << std::endl;
+
+    return 0;
+}

--- a/examples/task/scheduled_tasks/README.md
+++ b/examples/task/scheduled_tasks/README.md
@@ -1,0 +1,78 @@
+# Scheduled Tasks Example
+
+Demonstrates delayed and periodic task execution.
+
+## Features
+
+- Scheduling tasks with countdown delays
+- Creating periodic tasks that run at intervals
+- Using cron expressions for scheduling
+
+## Usage
+
+```bash
+./bin/example_task_scheduled_tasks
+```
+
+## Key Concepts
+
+### Delayed Execution
+
+```cpp
+system.submit_later(task, std::chrono::seconds(5));
+```
+
+### Periodic Scheduling
+
+```cpp
+system.schedule_periodic(
+    "schedule-name",
+    task,
+    std::chrono::seconds(2)
+);
+```
+
+### Cron-based Scheduling
+
+```cpp
+system.schedule_cron(
+    "schedule-name",
+    task,
+    "0 * * * * *"  // Every minute at second 0
+);
+```
+
+## Cron Expression Format
+
+```
+* * * * * *
+│ │ │ │ │ └── Day of week (0-6)
+│ │ │ │ └──── Month (1-12)
+│ │ │ └────── Day of month (1-31)
+│ │ └──────── Hour (0-23)
+│ └────────── Minute (0-59)
+└──────────── Second (0-59)
+```
+
+## Expected Output
+
+```
+=== Scheduled Tasks Example ===
+Start time: 12:00:00
+Task system started
+
+Scheduling delayed task (3 seconds)...
+Setting up periodic heartbeat (every 2 seconds)...
+Setting up cron task (for demonstration)...
+Scheduling another delayed task (5 seconds)...
+
+Waiting for scheduled tasks to execute...
+(Running for 8 seconds)
+
+[12:00:02] Heartbeat #1
+[12:00:03] Delayed task executed: This was delayed by 3 seconds
+[12:00:04] Heartbeat #2
+[12:00:05] Delayed task executed: This was delayed by 5 seconds
+[12:00:06] Heartbeat #3
+...
+```

--- a/examples/task/scheduled_tasks/main.cpp
+++ b/examples/task/scheduled_tasks/main.cpp
@@ -1,0 +1,180 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file main.cpp
+ * @brief Scheduled and periodic task example
+ *
+ * This example demonstrates:
+ * - Scheduling tasks with countdown delays
+ * - Creating periodic tasks with intervals
+ * - Using cron expressions for scheduling
+ */
+
+#include <kcenon/messaging/task/task_system.h>
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <thread>
+
+using namespace kcenon::messaging::task;
+using namespace kcenon::common;
+
+// Helper function to get current time as string
+std::string current_time() {
+    auto now = std::chrono::system_clock::now();
+    auto time_t = std::chrono::system_clock::to_time_t(now);
+    std::stringstream ss;
+    ss << std::put_time(std::localtime(&time_t), "%H:%M:%S");
+    return ss.str();
+}
+
+int main() {
+    std::cout << "=== Scheduled Tasks Example ===" << std::endl;
+    std::cout << "Start time: " << current_time() << std::endl;
+
+    // Configure with scheduler enabled
+    task_system_config config;
+    config.worker.concurrency = 2;
+    config.enable_scheduler = true;
+    task_system system(config);
+
+    // Counter for periodic task
+    std::atomic<int> heartbeat_count{0};
+
+    // Register a handler for delayed tasks
+    system.register_handler(
+        "delayed.task", [](const task& t, task_context& ctx) {
+            auto payload = t.payload();
+            auto message = payload.get_string("message").value_or("no message");
+
+            std::cout << "[" << current_time() << "] Delayed task executed: "
+                      << message << std::endl;
+
+            container_module::value_container result;
+            result.set_value("executed_at", current_time());
+            return ok(result);
+        });
+
+    // Register a handler for periodic heartbeat
+    system.register_handler(
+        "heartbeat", [&heartbeat_count](const task& t, task_context& ctx) {
+            int count = ++heartbeat_count;
+            std::cout << "[" << current_time() << "] Heartbeat #" << count
+                      << std::endl;
+
+            container_module::value_container result;
+            result.set_value("count", count);
+            return ok(result);
+        });
+
+    // Register a cleanup handler
+    system.register_handler("cleanup", [](const task& t, task_context& ctx) {
+        std::cout << "[" << current_time() << "] Running cleanup task"
+                  << std::endl;
+
+        container_module::value_container result;
+        result.set_value("status", std::string("cleaned"));
+        return ok(result);
+    });
+
+    // Start the system
+    auto start_result = system.start();
+    if (start_result.is_err()) {
+        std::cerr << "Failed to start: " << start_result.error().message
+                  << std::endl;
+        return 1;
+    }
+    std::cout << "Task system started\n" << std::endl;
+
+    // 1. Submit a task with countdown delay
+    std::cout << "Scheduling delayed task (3 seconds)..." << std::endl;
+    {
+        auto task_result = task_builder("delayed.task").build();
+        if (task_result.is_ok()) {
+            auto t = task_result.unwrap();
+            container_module::value_container payload;
+            payload.set_value("message",
+                              std::string("This was delayed by 3 seconds"));
+            t.set_task_payload(payload);
+            system.submit_later(std::move(t), std::chrono::seconds(3));
+        }
+    }
+
+    // 2. Schedule a periodic heartbeat (every 2 seconds)
+    std::cout << "Setting up periodic heartbeat (every 2 seconds)..."
+              << std::endl;
+    {
+        auto task_result = task_builder("heartbeat").build();
+        if (task_result.is_ok()) {
+            auto schedule_result = system.schedule_periodic(
+                "heartbeat-schedule", task_result.unwrap(),
+                std::chrono::seconds(2));
+            if (schedule_result.is_err()) {
+                std::cerr << "Failed to schedule: "
+                          << schedule_result.error().message << std::endl;
+            }
+        }
+    }
+
+    // 3. Schedule a cron-based task (every minute at :30 seconds)
+    // Note: This uses a simplified cron format
+    std::cout << "Setting up cron task (for demonstration)..." << std::endl;
+    {
+        auto task_result = task_builder("cleanup").build();
+        if (task_result.is_ok()) {
+            // Run every minute (at second 0)
+            auto schedule_result = system.schedule_cron(
+                "cleanup-schedule", task_result.unwrap(), "0 * * * * *");
+            if (schedule_result.is_err()) {
+                std::cout << "  (Cron scheduling may not trigger during demo)"
+                          << std::endl;
+            }
+        }
+    }
+
+    // 4. Submit another delayed task
+    std::cout << "Scheduling another delayed task (5 seconds)..." << std::endl;
+    {
+        auto task_result = task_builder("delayed.task").build();
+        if (task_result.is_ok()) {
+            auto t = task_result.unwrap();
+            container_module::value_container payload;
+            payload.set_value("message",
+                              std::string("This was delayed by 5 seconds"));
+            t.set_task_payload(payload);
+            system.submit_later(std::move(t), std::chrono::seconds(5));
+        }
+    }
+
+    std::cout << "\nWaiting for scheduled tasks to execute..." << std::endl;
+    std::cout << "(Running for 8 seconds)\n" << std::endl;
+
+    // Let the system run for a while
+    std::this_thread::sleep_for(std::chrono::seconds(8));
+
+    // Check scheduler status
+    if (system.scheduler()) {
+        auto schedules = system.scheduler()->list_schedules();
+        std::cout << "\n=== Active Schedules ===" << std::endl;
+        for (const auto& name : schedules) {
+            std::cout << "  - " << name << std::endl;
+        }
+    }
+
+    // Display statistics
+    auto stats = system.get_statistics();
+    std::cout << "\n=== Statistics ===" << std::endl;
+    std::cout << "Total tasks: " << stats.total_tasks << std::endl;
+    std::cout << "Succeeded: " << stats.succeeded_tasks << std::endl;
+    std::cout << "Heartbeats: " << heartbeat_count.load() << std::endl;
+
+    std::cout << "\nShutting down..." << std::endl;
+    system.shutdown_graceful(std::chrono::seconds(5));
+    std::cout << "Done! End time: " << current_time() << std::endl;
+
+    return 0;
+}

--- a/examples/task/simple_worker/README.md
+++ b/examples/task/simple_worker/README.md
@@ -1,0 +1,61 @@
+# Simple Worker Example
+
+Demonstrates basic usage of the Task module.
+
+## Features
+
+- Creating a `task_system` with default configuration
+- Registering handlers with lambda functions
+- Submitting tasks and waiting for results
+- Displaying statistics
+
+## Usage
+
+```bash
+./bin/example_task_simple_worker
+```
+
+## Key Concepts
+
+### Handler Registration
+
+```cpp
+system.register_handler("greet", [](const task& t, task_context& ctx) {
+    auto name = t.payload().get_string("name").value_or("World");
+
+    container_module::value_container result;
+    result.set_value("greeting", "Hello, " + name + "!");
+    return common::ok(result);
+});
+```
+
+### Task Submission
+
+```cpp
+container_module::value_container payload;
+payload.set_value("name", std::string("Task System"));
+
+auto result = system.submit("greet", payload);
+auto outcome = result.get(std::chrono::seconds(10));
+```
+
+## Expected Output
+
+```
+=== Simple Worker Example ===
+Task system started with 2 workers
+
+Submitting greeting task...
+Result: Hello, Task System!
+
+Submitting addition task (10 + 25)...
+Result: 35
+
+=== Statistics ===
+Total tasks: 2
+Succeeded: 2
+Failed: 0
+
+Shutting down...
+Done!
+```

--- a/examples/task/simple_worker/main.cpp
+++ b/examples/task/simple_worker/main.cpp
@@ -1,0 +1,128 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file main.cpp
+ * @brief Simple worker example demonstrating basic Task module usage
+ *
+ * This example shows:
+ * - Creating a task_system with default configuration
+ * - Registering a handler with a lambda function
+ * - Submitting a task and waiting for the result
+ */
+
+#include <kcenon/messaging/task/task_system.h>
+#include <iostream>
+#include <string>
+
+using namespace kcenon::messaging::task;
+using namespace kcenon::common;
+
+int main() {
+    std::cout << "=== Simple Worker Example ===" << std::endl;
+
+    // Create task system with default configuration
+    task_system_config config;
+    config.worker.concurrency = 2;  // Use 2 worker threads
+    task_system system(config);
+
+    // Register a simple handler that processes greetings
+    system.register_handler("greet", [](const task& t, task_context& ctx) {
+        ctx.log_info("Processing greeting task");
+
+        // Get the name from the payload
+        auto payload = t.payload();
+        auto name_opt = payload.get_string("name");
+        std::string name = name_opt.value_or("World");
+
+        // Create the result
+        container_module::value_container result;
+        result.set_value("greeting", "Hello, " + name + "!");
+        result.set_value("processed", true);
+
+        ctx.update_progress(1.0, "Completed");
+        return ok(result);
+    });
+
+    // Register an addition handler
+    system.register_handler("add", [](const task& t, task_context& ctx) {
+        auto payload = t.payload();
+        auto a_opt = payload.get_value<int>("a");
+        auto b_opt = payload.get_value<int>("b");
+
+        if (!a_opt || !b_opt) {
+            return Result<container_module::value_container>(
+                error_info{-1, "Missing 'a' or 'b' parameter"});
+        }
+
+        int sum = a_opt.value() + b_opt.value();
+
+        container_module::value_container result;
+        result.set_value("sum", sum);
+        ctx.log_info("Calculated sum: " + std::to_string(sum));
+
+        return ok(result);
+    });
+
+    // Start the system
+    auto start_result = system.start();
+    if (start_result.is_err()) {
+        std::cerr << "Failed to start system: " << start_result.error().message
+                  << std::endl;
+        return 1;
+    }
+    std::cout << "Task system started with " << system.total_workers()
+              << " workers" << std::endl;
+
+    // Submit greeting task
+    container_module::value_container greet_payload;
+    greet_payload.set_value("name", std::string("Task System"));
+
+    std::cout << "\nSubmitting greeting task..." << std::endl;
+    auto greet_result = system.submit("greet", greet_payload);
+
+    // Wait for the result with timeout
+    auto greet_outcome = greet_result.get(std::chrono::seconds(10));
+    if (greet_outcome.is_ok()) {
+        auto value = greet_outcome.unwrap();
+        auto greeting = value.get_string("greeting");
+        std::cout << "Result: " << greeting.value_or("(no greeting)")
+                  << std::endl;
+    } else {
+        std::cerr << "Greeting task failed: " << greet_outcome.error().message
+                  << std::endl;
+    }
+
+    // Submit addition task
+    container_module::value_container add_payload;
+    add_payload.set_value("a", 10);
+    add_payload.set_value("b", 25);
+
+    std::cout << "\nSubmitting addition task (10 + 25)..." << std::endl;
+    auto add_result = system.submit("add", add_payload);
+
+    auto add_outcome = add_result.get(std::chrono::seconds(10));
+    if (add_outcome.is_ok()) {
+        auto value = add_outcome.unwrap();
+        auto sum = value.get_value<int>("sum");
+        std::cout << "Result: " << sum.value_or(0) << std::endl;
+    } else {
+        std::cerr << "Addition task failed: " << add_outcome.error().message
+                  << std::endl;
+    }
+
+    // Display statistics
+    auto stats = system.get_statistics();
+    std::cout << "\n=== Statistics ===" << std::endl;
+    std::cout << "Total tasks: " << stats.total_tasks << std::endl;
+    std::cout << "Succeeded: " << stats.succeeded_tasks << std::endl;
+    std::cout << "Failed: " << stats.failed_tasks << std::endl;
+
+    // Stop the system gracefully
+    std::cout << "\nShutting down..." << std::endl;
+    system.shutdown_graceful(std::chrono::seconds(5));
+
+    std::cout << "Done!" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Add 7 comprehensive example applications for the Task module
- Each example demonstrates a specific feature or pattern
- Include README documentation for each example

## Examples Added

| Example | Description |
|---------|-------------|
| simple_worker | Basic handler registration and task submission |
| priority_tasks | Priority-based task processing |
| scheduled_tasks | Delayed and periodic task execution with cron |
| chain_workflow | Sequential ETL pipeline pattern |
| chord_aggregation | Parallel execution with result aggregation |
| progress_tracking | Real-time progress updates for long tasks |
| monitoring_dashboard | Console-based system monitoring |

## Changes

- Added `examples/task/` directory with 7 example applications
- Added `examples/task/CMakeLists.txt` for building examples
- Updated `examples/CMakeLists.txt` to include task examples
- Added README.md for each example with usage instructions

## Test plan

- [ ] Build all examples with `cmake --build . --target example_task_simple_worker`
- [ ] Run each example to verify expected output
- [ ] Verify examples compile without warnings

Closes #116