### PR TITLE
refactor(task): integrate worker_pool with thread_system

### DIFF
--- a/docs/task/ARCHITECTURE.md
+++ b/docs/task/ARCHITECTURE.md
@@ -404,12 +404,19 @@ All public APIs are thread-safe:
 
 ### thread_system Integration
 
-The `task_queue` component uses `thread_system` for managing the delayed task worker thread. Instead of direct `std::thread` usage, it leverages `kcenon::thread::thread_base` which provides:
+Both `task_queue` and `worker_pool` components use `thread_system` for thread management. Instead of direct `std::thread` usage, they leverage `kcenon::thread::thread_base` which provides:
 
 - Standardized thread lifecycle management (start/stop)
 - Proper wake interval handling for periodic tasks
 - Consistent thread naming and monitoring
 - Integration with the project's threading infrastructure
+
+**task_queue**: Uses `thread_base` for the delayed task worker thread that processes scheduled tasks.
+
+**worker_pool**: Uses `thread_base` through the `task_pool_worker` class. Each worker thread inherits from `thread_base`, delegating thread lifecycle management to `thread_system`. This replaces direct `std::thread` usage with:
+- `task_pool_worker::do_work()` for per-task processing
+- `task_pool_worker::should_continue_work()` for shutdown coordination
+- Automatic wake interval configuration matching the pool's poll interval
 
 ## Extension Points
 

--- a/docs/task/ARCHITECTURE_KO.md
+++ b/docs/task/ARCHITECTURE_KO.md
@@ -409,12 +409,19 @@ result.then(
 
 ### thread_system 통합
 
-`task_queue` 컴포넌트는 지연된 태스크 워커 스레드 관리를 위해 `thread_system`을 사용합니다. 직접적인 `std::thread` 사용 대신 `kcenon::thread::thread_base`를 활용하여 다음을 제공합니다:
+`task_queue`와 `worker_pool` 컴포넌트 모두 스레드 관리를 위해 `thread_system`을 사용합니다. 직접적인 `std::thread` 사용 대신 `kcenon::thread::thread_base`를 활용하여 다음을 제공합니다:
 
 - 표준화된 스레드 수명 주기 관리 (시작/중지)
 - 주기적 태스크를 위한 적절한 wake interval 처리
 - 일관된 스레드 명명 및 모니터링
 - 프로젝트의 스레딩 인프라와의 통합
+
+**task_queue**: 예약된 태스크를 처리하는 지연 태스크 워커 스레드에 `thread_base`를 사용합니다.
+
+**worker_pool**: `task_pool_worker` 클래스를 통해 `thread_base`를 사용합니다. 각 워커 스레드는 `thread_base`를 상속하여 스레드 수명 주기 관리를 `thread_system`에 위임합니다. 이를 통해 직접적인 `std::thread` 사용을 다음으로 대체합니다:
+- 태스크별 처리를 위한 `task_pool_worker::do_work()`
+- 종료 조정을 위한 `task_pool_worker::should_continue_work()`
+- 풀의 poll interval에 맞춘 자동 wake interval 구성
 
 ## 확장 포인트
 


### PR DESCRIPTION
## Summary

- Replace direct `std::thread` usage with `thread_system`'s `thread_base` class for worker thread management
- Add `task_pool_worker` class inheriting from `kcenon::thread::thread_base`
- Refactor `worker_loop()` to `process_one_task()` for single task processing
- Update architecture documentation (EN/KO)

## Changes

### Code Changes
- **worker_pool.h**: Add `task_pool_worker` class, change `workers_` type to `std::vector<std::unique_ptr<task_pool_worker>>`
- **worker_pool.cpp**: Implement `task_pool_worker`, refactor `start()`/`stop()` to use `thread_base` lifecycle

### Documentation
- Update ARCHITECTURE.md and ARCHITECTURE_KO.md with thread_system integration details for worker_pool

## Benefits

- Standardized thread lifecycle management across task_queue and worker_pool components
- Consistent thread naming and monitoring
- Reduced threading code maintenance burden (~405 lines of direct threading code now delegated)
- Integration with project's threading infrastructure

## Test Plan

- [x] All 26 worker_pool unit tests pass
- [x] All 26 task_system tests pass
- [x] All 29 task_queue tests pass
- [x] All 24 task_client tests pass
- [x] All 37 task tests pass
- [x] No performance regression expected (same execution model)

## Acceptance Criteria (from Issue #137)

- [x] `worker_pool` uses `thread_system` for thread management
- [x] All existing unit tests pass
- [x] Configuration options (concurrency, etc.) still work
- [x] Graceful shutdown behavior preserved

Closes #137