### PR TITLE
docs(adr): add ADR-001 for logging architecture review

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -73,6 +73,10 @@ The messaging system integrates multiple high-performance modules:
 - **[Task Module Troubleshooting](./task/TROUBLESHOOTING.md)** - Common issues and debugging
 - **[Task Module Migration](./task/MIGRATION.md)** - Migration from other systems
 
+### Architecture Decision Records (ADR)
+- **[ADR Index](./adr/README.md)** - Architecture Decision Records index
+- **[ADR-001: Logging Architecture](./adr/001-logging-architecture.md)** - ILogger interface vs logger_system
+
 ## 📖 Documentation Standards
 
 All documentation follows these principles:

--- a/docs/README_KO.md
+++ b/docs/README_KO.md
@@ -55,6 +55,15 @@
 
 ---
 
+## 아키텍처 결정 기록 (ADR)
+
+| 문서 | 설명 |
+|------|------|
+| [ADR 인덱스](adr/README.md) | ADR 목록 및 템플릿 |
+| [ADR-001: 로깅 아키텍처](adr/001-logging-architecture_KO.md) | ILogger 인터페이스 vs logger_system |
+
+---
+
 ## 디렉토리 구조
 
 ```
@@ -80,14 +89,18 @@ docs/
 │   ├── PERFORMANCE.md
 │   └── BASELINE.md
 │
-└── task/               # Task 큐 시스템 문서
-    ├── QUICK_START.md
-    ├── ARCHITECTURE.md
-    ├── API_REFERENCE.md
-    ├── PATTERNS.md
-    ├── CONFIGURATION.md
-    ├── TROUBLESHOOTING.md
-    └── MIGRATION.md
+├── task/               # Task 큐 시스템 문서
+│   ├── QUICK_START.md
+│   ├── ARCHITECTURE.md
+│   ├── API_REFERENCE.md
+│   ├── PATTERNS.md
+│   ├── CONFIGURATION.md
+│   ├── TROUBLESHOOTING.md
+│   └── MIGRATION.md
+│
+└── adr/                # 아키텍처 결정 기록
+    ├── README.md
+    └── 001-logging-architecture.md
 ```
 
 ---

--- a/docs/adr/001-logging-architecture.md
+++ b/docs/adr/001-logging-architecture.md
@@ -1,0 +1,193 @@
+# ADR-001: Logging Architecture - ILogger Interface vs logger_system
+
+## Status
+
+**Accepted** - Current implementation is correct
+
+## Context
+
+The messaging_system project uses logging throughout its codebase. This ADR documents the architectural decision regarding how logging is integrated and the relationship between `common_system::ILogger` and `logger_system`.
+
+### Background
+
+The project initially had a direct dependency on `logger_system` for logging functionality. This created tight coupling and potential circular dependency issues, particularly between `thread_system` and `logger_system`.
+
+### Problem Statement
+
+1. Direct dependency on `logger_system` created tight coupling
+2. Circular dependencies were possible between core systems
+3. Testing required full logger_system initialization
+4. Applications without logging needs still pulled in the entire logger implementation
+
+## Decision
+
+Use `common_system::ILogger` interface with runtime binding via `GlobalLoggerRegistry` instead of direct `logger_system` dependency.
+
+### Architecture Overview
+
+```
+messaging_system
+    |
+    v
+common::logging::log_info/error/debug (convenience functions)
+    |
+    v
+GlobalLoggerRegistry::instance() (thread-safe singleton)
+    |
+    v
+common::interfaces::ILogger (abstract interface)
+    |
+    v (optional runtime binding)
+logger_system::logger (concrete implementation)
+    |
+    v
+logger_adapter (ILogger adapter)
+```
+
+### Implementation Details
+
+#### 1. ILogger Interface (`common_system`)
+
+Location: `common_system/include/kcenon/common/interfaces/logger_interface.h`
+
+```cpp
+class ILogger {
+public:
+    virtual void log(log_level level, std::string_view message,
+                     const source_location& loc = source_location::current()) = 0;
+    virtual void log(const log_entry& entry) = 0;
+    virtual bool is_enabled(log_level level) const = 0;
+    virtual void set_level(log_level level) = 0;
+    virtual log_level get_level() const = 0;
+    virtual void flush() = 0;
+};
+```
+
+#### 2. GlobalLoggerRegistry (`common_system`)
+
+Location: `common_system/include/kcenon/common/interfaces/global_logger_registry.h`
+
+Features:
+- Thread-safe singleton (Meyer's singleton pattern)
+- Named logger management via `register_logger()`, `get_logger()`
+- Default logger management via `set_default_logger()`, `get_default_logger()`
+- Factory-based lazy initialization with `register_factory()`
+- NullLogger fallback for safe operation without logger
+
+#### 3. Convenience Functions (`common_system`)
+
+Location: `common_system/include/kcenon/common/logging/log_functions.h`
+
+```cpp
+namespace common::logging {
+    void log_info(const std::string& message);
+    void log_error(const std::string& message);
+    void log_debug(const std::string& message);
+    void log_warning(const std::string& message);
+    void log_trace(const std::string& message);
+    void log_critical(const std::string& message);
+}
+```
+
+#### 4. CMake Dependency Configuration
+
+Location: `messaging_system/CMakeLists.txt` (lines 126-128)
+
+```cmake
+# NOTE: logger_system is no longer a direct dependency (Issue #94).
+# Logging is now provided through common_system's ILogger interface
+# with runtime binding via GlobalLoggerRegistry.
+```
+
+## Consequences
+
+### Positive
+
+1. **Zero Coupling**: messaging_system has no compile-time dependency on logger_system
+2. **Optional Integration**: Works with or without logger_system installed
+3. **Safe Defaults**: NullLogger prevents null pointer crashes when no logger is configured
+4. **Flexible Binding**: Different ILogger implementations can be bound at runtime
+5. **Circular Dependency Resolution**: Breaks the thread_system <-> logger_system cycle
+6. **Testability**: Unit tests can run without full logger initialization
+7. **Reduced Binary Size**: Applications not using logging don't include logger_system
+
+### Negative
+
+1. **Runtime Overhead**: Virtual function calls instead of direct calls (minimal impact)
+2. **Configuration Complexity**: Requires explicit logger registration at application startup
+3. **Feature Limitation**: Some logger_system-specific features require direct dependency
+
+### Neutral
+
+1. **Documentation Requirement**: Architecture needs clear documentation (this ADR)
+2. **Migration Effort**: Existing code using logger_system directly needs refactoring
+
+## Alternatives Considered
+
+### Alternative A: Direct logger_system Dependency
+
+**Rejected** because:
+- Creates tight coupling
+- Prevents optional logging
+- Causes circular dependency issues
+
+### Alternative B: Compile-time Logger Selection via Templates
+
+**Rejected** because:
+- Increases binary size (template instantiation)
+- Reduces flexibility for runtime configuration
+- More complex API
+
+### Alternative C: Macro-based Logging
+
+**Rejected** because:
+- Less type-safe
+- Harder to maintain
+- Doesn't integrate well with C++20 features
+
+## Compliance
+
+### Current Implementation Status
+
+| Requirement | Status | Notes |
+|-------------|--------|-------|
+| ILogger interface usage | Complete | All logging via convenience functions |
+| No direct logger_system dependency | Complete | CMakeLists.txt verified |
+| GlobalLoggerRegistry integration | Complete | Thread-safe singleton |
+| NullLogger fallback | Complete | Safe default behavior |
+| Source location support | Complete | C++20 source_location |
+
+### Usage Examples in messaging_system
+
+```cpp
+// src/impl/core/message_bus.cpp
+#include <kcenon/common/logging/log_functions.h>
+
+void message_bus::start() {
+    common::logging::log_info("Starting message bus with " +
+                               std::to_string(worker_count) + " workers");
+}
+
+void message_bus::on_error(const std::string& error) {
+    common::logging::log_error("Failed to process message: " + error);
+}
+```
+
+## Related Decisions
+
+- **Issue #94**: Migration from direct logger_system dependency
+- **Issue #139**: Thread pool architecture decision (similar pattern)
+
+## References
+
+- `common_system/include/kcenon/common/interfaces/logger_interface.h`
+- `common_system/include/kcenon/common/interfaces/global_logger_registry.h`
+- `common_system/include/kcenon/common/logging/log_functions.h`
+- `messaging_system/CMakeLists.txt`
+- `messaging_system/include/kcenon/messaging/utils/integration_detector.h`
+
+## Revision History
+
+| Date | Version | Author | Changes |
+|------|---------|--------|---------|
+| 2025-12-10 | 1.0 | - | Initial ADR creation |

--- a/docs/adr/001-logging-architecture_KO.md
+++ b/docs/adr/001-logging-architecture_KO.md
@@ -1,0 +1,193 @@
+# ADR-001: 로깅 아키텍처 - ILogger 인터페이스 vs logger_system
+
+## 상태
+
+**승인됨** - 현재 구현이 올바름
+
+## 배경
+
+messaging_system 프로젝트는 코드베이스 전반에 걸쳐 로깅을 사용합니다. 이 ADR은 로깅 통합 방식과 `common_system::ILogger` 및 `logger_system` 간의 관계에 대한 아키텍처 결정을 문서화합니다.
+
+### 배경 설명
+
+프로젝트는 초기에 로깅 기능을 위해 `logger_system`에 직접 의존했습니다. 이로 인해 강한 결합과 잠재적인 순환 의존성 문제가 발생했으며, 특히 `thread_system`과 `logger_system` 사이에서 문제가 되었습니다.
+
+### 문제 정의
+
+1. `logger_system`에 대한 직접 의존성으로 인한 강한 결합
+2. 핵심 시스템 간 순환 의존성 가능성
+3. 테스트 시 전체 logger_system 초기화 필요
+4. 로깅이 필요 없는 애플리케이션도 전체 로거 구현을 포함해야 함
+
+## 결정
+
+`logger_system` 직접 의존성 대신 `GlobalLoggerRegistry`를 통한 런타임 바인딩과 함께 `common_system::ILogger` 인터페이스를 사용합니다.
+
+### 아키텍처 개요
+
+```
+messaging_system
+    |
+    v
+common::logging::log_info/error/debug (편의 함수)
+    |
+    v
+GlobalLoggerRegistry::instance() (스레드 안전 싱글톤)
+    |
+    v
+common::interfaces::ILogger (추상 인터페이스)
+    |
+    v (선택적 런타임 바인딩)
+logger_system::logger (구체적 구현)
+    |
+    v
+logger_adapter (ILogger 어댑터)
+```
+
+### 구현 세부사항
+
+#### 1. ILogger 인터페이스 (`common_system`)
+
+위치: `common_system/include/kcenon/common/interfaces/logger_interface.h`
+
+```cpp
+class ILogger {
+public:
+    virtual void log(log_level level, std::string_view message,
+                     const source_location& loc = source_location::current()) = 0;
+    virtual void log(const log_entry& entry) = 0;
+    virtual bool is_enabled(log_level level) const = 0;
+    virtual void set_level(log_level level) = 0;
+    virtual log_level get_level() const = 0;
+    virtual void flush() = 0;
+};
+```
+
+#### 2. GlobalLoggerRegistry (`common_system`)
+
+위치: `common_system/include/kcenon/common/interfaces/global_logger_registry.h`
+
+기능:
+- 스레드 안전 싱글톤 (Meyer's 싱글톤 패턴)
+- `register_logger()`, `get_logger()`를 통한 명명된 로거 관리
+- `set_default_logger()`, `get_default_logger()`를 통한 기본 로거 관리
+- `register_factory()`를 통한 팩토리 기반 지연 초기화
+- 로거 없이도 안전한 작동을 위한 NullLogger 폴백
+
+#### 3. 편의 함수 (`common_system`)
+
+위치: `common_system/include/kcenon/common/logging/log_functions.h`
+
+```cpp
+namespace common::logging {
+    void log_info(const std::string& message);
+    void log_error(const std::string& message);
+    void log_debug(const std::string& message);
+    void log_warning(const std::string& message);
+    void log_trace(const std::string& message);
+    void log_critical(const std::string& message);
+}
+```
+
+#### 4. CMake 의존성 구성
+
+위치: `messaging_system/CMakeLists.txt` (126-128행)
+
+```cmake
+# NOTE: logger_system is no longer a direct dependency (Issue #94).
+# Logging is now provided through common_system's ILogger interface
+# with runtime binding via GlobalLoggerRegistry.
+```
+
+## 결과
+
+### 긍정적
+
+1. **제로 결합**: messaging_system은 logger_system에 대한 컴파일 타임 의존성이 없음
+2. **선택적 통합**: logger_system 설치 여부와 관계없이 작동
+3. **안전한 기본값**: 로거가 구성되지 않았을 때 NullLogger가 널 포인터 충돌 방지
+4. **유연한 바인딩**: 런타임에 다른 ILogger 구현을 바인딩 가능
+5. **순환 의존성 해결**: thread_system <-> logger_system 사이클 해소
+6. **테스트 용이성**: 전체 로거 초기화 없이 단위 테스트 실행 가능
+7. **바이너리 크기 감소**: 로깅을 사용하지 않는 애플리케이션은 logger_system을 포함하지 않음
+
+### 부정적
+
+1. **런타임 오버헤드**: 직접 호출 대신 가상 함수 호출 (최소한의 영향)
+2. **구성 복잡성**: 애플리케이션 시작 시 명시적 로거 등록 필요
+3. **기능 제한**: 일부 logger_system 전용 기능은 직접 의존성 필요
+
+### 중립적
+
+1. **문서화 필요**: 아키텍처에 대한 명확한 문서화 필요 (이 ADR)
+2. **마이그레이션 노력**: logger_system을 직접 사용하는 기존 코드 리팩토링 필요
+
+## 고려된 대안
+
+### 대안 A: logger_system 직접 의존성
+
+**거부됨** 이유:
+- 강한 결합 생성
+- 선택적 로깅 방지
+- 순환 의존성 문제 발생
+
+### 대안 B: 템플릿을 통한 컴파일 타임 로거 선택
+
+**거부됨** 이유:
+- 바이너리 크기 증가 (템플릿 인스턴스화)
+- 런타임 구성 유연성 감소
+- 더 복잡한 API
+
+### 대안 C: 매크로 기반 로깅
+
+**거부됨** 이유:
+- 타입 안전성 부족
+- 유지보수 어려움
+- C++20 기능과의 통합 어려움
+
+## 준수 사항
+
+### 현재 구현 상태
+
+| 요구사항 | 상태 | 비고 |
+|---------|------|-----|
+| ILogger 인터페이스 사용 | 완료 | 모든 로깅이 편의 함수를 통함 |
+| logger_system 직접 의존성 없음 | 완료 | CMakeLists.txt 확인됨 |
+| GlobalLoggerRegistry 통합 | 완료 | 스레드 안전 싱글톤 |
+| NullLogger 폴백 | 완료 | 안전한 기본 동작 |
+| 소스 위치 지원 | 완료 | C++20 source_location |
+
+### messaging_system에서의 사용 예시
+
+```cpp
+// src/impl/core/message_bus.cpp
+#include <kcenon/common/logging/log_functions.h>
+
+void message_bus::start() {
+    common::logging::log_info("Starting message bus with " +
+                               std::to_string(worker_count) + " workers");
+}
+
+void message_bus::on_error(const std::string& error) {
+    common::logging::log_error("Failed to process message: " + error);
+}
+```
+
+## 관련 결정
+
+- **Issue #94**: logger_system 직접 의존성에서 마이그레이션
+- **Issue #139**: 스레드 풀 아키텍처 결정 (유사한 패턴)
+
+## 참조
+
+- `common_system/include/kcenon/common/interfaces/logger_interface.h`
+- `common_system/include/kcenon/common/interfaces/global_logger_registry.h`
+- `common_system/include/kcenon/common/logging/log_functions.h`
+- `messaging_system/CMakeLists.txt`
+- `messaging_system/include/kcenon/messaging/utils/integration_detector.h`
+
+## 수정 이력
+
+| 날짜 | 버전 | 작성자 | 변경사항 |
+|-----|------|-------|---------|
+| 2025-12-10 | 1.0 | - | 초기 ADR 작성 |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,67 @@
+# Architecture Decision Records (ADR)
+
+This directory contains Architecture Decision Records (ADRs) for the messaging_system project. ADRs document significant architectural decisions made during the development of the system.
+
+## What is an ADR?
+
+An Architecture Decision Record is a document that captures an important architectural decision made along with its context and consequences.
+
+## ADR Index
+
+| ADR | Title | Status | Date |
+|-----|-------|--------|------|
+| [001](001-logging-architecture.md) | Logging Architecture - ILogger Interface vs logger_system | Accepted | 2025-12-10 |
+
+## ADR Status
+
+- **Proposed**: The decision is under discussion
+- **Accepted**: The decision has been accepted and is being implemented
+- **Deprecated**: The decision is no longer valid
+- **Superseded**: The decision has been replaced by another decision
+
+## Creating a New ADR
+
+1. Copy the template below
+2. Name the file `NNN-title.md` where NNN is the next number
+3. Fill in the sections
+4. Submit a PR for review
+
+## ADR Template
+
+```markdown
+# ADR-NNN: [Title]
+
+## Status
+
+[Proposed | Accepted | Deprecated | Superseded by ADR-XXX]
+
+## Context
+
+[Describe the context and problem statement]
+
+## Decision
+
+[Describe the decision and the reasoning behind it]
+
+## Consequences
+
+### Positive
+[List positive consequences]
+
+### Negative
+[List negative consequences]
+
+## Alternatives Considered
+
+[List alternatives that were considered]
+
+## References
+
+[List relevant references]
+```
+
+## Related Documentation
+
+- [Architecture Overview](../ARCHITECTURE.md)
+- [Project Structure](../PROJECT_STRUCTURE.md)
+- [System Architecture](../advanced/SYSTEM_ARCHITECTURE.md)


### PR DESCRIPTION
## Summary

- Add Architecture Decision Record (ADR-001) documenting the logging architecture decision
- Document that current approach using `common_system::ILogger` is correct and should remain unchanged
- Create ADR directory structure for future architecture decisions
- Update documentation index to include ADR section

## Investigation Findings

### Current Architecture (Correct)

```
messaging_system
    ↓
common::logging::log_info/error/debug (convenience functions)
    ↓
GlobalLoggerRegistry::instance() (thread-safe singleton)
    ↓
common::interfaces::ILogger (abstract interface)
    ↓ (optional runtime binding)
logger_system::logger (implementation)
```

### Benefits of Current Approach

1. **Zero Coupling**: messaging_system has no compile-time dependency on logger_system
2. **Optional Integration**: Works with or without logger_system installed
3. **Safe Defaults**: NullLogger prevents null pointer crashes
4. **Flexible Binding**: Different ILogger implementations can be bound at runtime
5. **Circular Dependency Resolution**: Breaks thread_system <-> logger_system cycle

### Conclusion

**Outcome C: Documentation Update Only** - The current design is correct but needed better documentation. This PR adds an ADR to document the architecture decision.

## Files Changed

- `docs/adr/001-logging-architecture.md` - Main ADR document (English)
- `docs/adr/001-logging-architecture_KO.md` - Korean translation
- `docs/adr/README.md` - ADR index and template
- `docs/README.md` - Updated with ADR section
- `docs/README_KO.md` - Updated with ADR section (Korean)

## Test Plan

- [x] Verify all markdown files are properly formatted
- [x] Verify links in documentation are correct
- [x] Review ADR content for accuracy

Closes #140