### PR TITLE
refactor(message_bus): migrate workers to backend executor

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -479,6 +479,24 @@ Features:
 - **Monitoring Access**: Optional monitoring integration
 - **Lifecycle Management**: Initialize and shutdown
 
+### Executor Integration
+
+**Worker threads managed by backend executor**
+
+The message bus uses the backend's executor (IExecutor) to manage worker threads instead of raw std::async calls. This provides:
+
+- **Unified Thread Pool**: Workers share the thread pool with other subsystems
+- **Better Resource Control**: Thread pool configuration in one place
+- **Job-based Execution**: Workers use IJob interface for better testability
+- **Automatic Fallback**: Falls back to std::async if executor unavailable
+
+```cpp
+// Workers automatically use executor when available
+auto backend = std::make_shared<standalone_backend>(4);  // 4 threads in pool
+auto bus = std::make_shared<message_bus>(backend, config);
+bus->start();  // Workers use backend's executor
+```
+
 ### Standalone Backend
 
 **Self-contained execution**

--- a/include/kcenon/messaging/core/message_bus.h
+++ b/include/kcenon/messaging/core/message_bus.h
@@ -42,11 +42,16 @@ struct message_bus_config {
     std::string local_node_id;  ///< Unique identifier for distributed routing
 };
 
+// Forward declaration for friend class
+class message_processing_job;
+
 /**
  * @class message_bus
  * @brief Central message hub for publish-subscribe messaging
  */
 class message_bus {
+    friend class message_processing_job;
+
     message_bus_config config_;
     std::shared_ptr<backend_interface> backend_;
     std::unique_ptr<message_queue> queue_;
@@ -121,6 +126,7 @@ public:
 
 private:
     void process_messages();
+    void process_single_message();
     common::VoidResult handle_message(const message& msg);
     void start_workers();
     void stop_workers();


### PR DESCRIPTION
## Summary

- Replace `std::async` usage in `message_bus` with `backend_interface`'s `IExecutor` for consistent thread pool management
- Create `message_processing_job` class implementing `IJob` interface
- Add automatic fallback to `std::async` when executor is unavailable
- Add unit tests for executor-based worker execution

## Changes

### Core Implementation
- **message_processing_job**: New job class that encapsulates message processing logic for use with IExecutor
- **start_workers()**: Now uses `backend->get_executor()->execute()` instead of `std::async`
- **process_single_message()**: New method extracted from `process_messages()` for job-based execution

### Backward Compatibility
- Automatic fallback to `std::async` when:
  - Backend's executor is null
  - Executor is not running

### Tests Added
- `MessageBusExecutorTest.WorkersUseExecutorWhenAvailable`
- `MessageBusExecutorTest.GracefulShutdownWithExecutor`
- `MessageBusExecutorTest.ConcurrentProcessingWithExecutor`
- `MessageBusIntegrationBackendTest.WorksWithExternalExecutor`

## Test Plan

- [x] All 28 existing message_bus tests pass
- [x] New executor integration tests pass
- [x] Verified executor-based workers process messages correctly
- [x] Verified graceful shutdown with executor
- [x] Verified fallback mechanism works

Closes #169