### PR TITLE
refactor(error): add messaging_error_category for typed error codes (Issue #229)

### DIFF
--- a/include/kcenon/messaging/error/messaging_error_category.h
+++ b/include/kcenon/messaging/error/messaging_error_category.h
@@ -1,0 +1,114 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file messaging_error_category.h
+ * @brief Error category for messaging_system typed error codes
+ *
+ * Provides a messaging-specific error category that integrates with
+ * common_system's typed_error_code infrastructure. This enables:
+ * - Type-safe error codes that carry their origin category
+ * - Direct integration with Result<T> via typed_error_code
+ * - Clear identification of messaging errors vs other system errors
+ *
+ * Usage Example:
+ * @code
+ * #include <kcenon/messaging/error/messaging_error_category.h>
+ *
+ * // Create a typed error code
+ * auto ec = kcenon::messaging::make_messaging_error_code(
+ *     kcenon::messaging::error::queue_full);
+ *
+ * // Use with Result<T>
+ * return Result<void>::err(ec);
+ *
+ * // Check category
+ * if (ec.category() == messaging_error_category::instance()) {
+ *     // Handle messaging-specific error
+ * }
+ * @endcode
+ *
+ * @see error_codes.h for error code constants
+ * @see common_system's error_category.h for base class
+ */
+
+#pragma once
+
+#include "error_codes.h"
+
+#include <kcenon/common/error/error_category.h>
+
+namespace kcenon::messaging {
+
+/**
+ * @class messaging_error_category
+ * @brief Error category for messaging_system error codes
+ *
+ * Singleton error category that maps messaging error codes (-700 to -799)
+ * to human-readable messages. Inherits from common::error_category and
+ * follows the same pattern as common_error_category.
+ *
+ * Thread Safety:
+ * - Stateless singleton, safe for concurrent access
+ * - C++11 guarantees thread-safe static local initialization
+ */
+class messaging_error_category : public common::error_category {
+public:
+    /**
+     * @brief Returns the singleton instance
+     *
+     * Thread-safe due to C++11 static local variable initialization.
+     *
+     * @return Reference to the singleton instance
+     */
+    static const messaging_error_category& instance() noexcept {
+        static messaging_error_category inst;
+        return inst;
+    }
+
+    /**
+     * @brief Returns the category name
+     * @return "messaging"
+     */
+    std::string_view name() const noexcept override {
+        return "messaging";
+    }
+
+    /**
+     * @brief Returns a human-readable message for the error code
+     *
+     * Delegates to error::get_error_message() which contains the
+     * canonical mapping for all messaging error codes.
+     *
+     * @param code Error code value (expected range: -700 to -799)
+     * @return Human-readable error message
+     */
+    std::string message(int code) const override {
+        return std::string(error::get_error_message(code));
+    }
+
+private:
+    messaging_error_category() = default;
+};
+
+/**
+ * @brief Create a typed_error_code for a messaging error code
+ *
+ * Convenience function that wraps an integer error code with the
+ * messaging_error_category.
+ *
+ * @param code Messaging error code (from error:: namespace)
+ * @return typed_error_code with messaging_error_category
+ *
+ * @code
+ * auto ec = make_messaging_error_code(error::queue_full);
+ * // ec.category().name() == "messaging"
+ * // ec.message() == "Message queue full"
+ * @endcode
+ */
+inline common::typed_error_code make_messaging_error_code(int code) noexcept {
+    return common::typed_error_code(code, messaging_error_category::instance());
+}
+
+} // namespace kcenon::messaging

--- a/test/unit/core/CMakeLists.txt
+++ b/test/unit/core/CMakeLists.txt
@@ -74,3 +74,18 @@ target_link_libraries(test_message_broker
 
 add_test(NAME test_message_broker COMMAND test_message_broker)
 set_tests_properties(test_message_broker PROPERTIES TIMEOUT 60)
+
+# Test: messaging_error_category
+add_executable(test_messaging_error_category
+    test_messaging_error_category.cpp
+)
+
+target_link_libraries(test_messaging_error_category
+    PRIVATE
+        messaging_system_core
+        GTest::gtest
+        GTest::gtest_main
+)
+
+add_test(NAME test_messaging_error_category COMMAND test_messaging_error_category)
+set_tests_properties(test_messaging_error_category PROPERTIES TIMEOUT 60)

--- a/test/unit/core/test_messaging_error_category.cpp
+++ b/test/unit/core/test_messaging_error_category.cpp
@@ -1,0 +1,147 @@
+#include <kcenon/messaging/error/messaging_error_category.h>
+#include <kcenon/common/patterns/result_helpers.h>
+#include <gtest/gtest.h>
+
+namespace msg = kcenon::messaging;
+namespace cmn = kcenon::common;
+
+// =============================================================================
+// Singleton Tests
+// =============================================================================
+
+TEST(MessagingErrorCategoryTest, SingletonIdentity) {
+    const auto& cat1 = msg::messaging_error_category::instance();
+    const auto& cat2 = msg::messaging_error_category::instance();
+
+    EXPECT_EQ(&cat1, &cat2);
+}
+
+TEST(MessagingErrorCategoryTest, CategoryName) {
+    const auto& cat = msg::messaging_error_category::instance();
+
+    EXPECT_EQ(cat.name(), "messaging");
+}
+
+// =============================================================================
+// Message Lookup Tests
+// =============================================================================
+
+TEST(MessagingErrorCategoryTest, MessageErrorCodes) {
+    const auto& cat = msg::messaging_error_category::instance();
+
+    EXPECT_EQ(cat.message(msg::error::invalid_message), "Invalid message");
+    EXPECT_EQ(cat.message(msg::error::message_too_large), "Message too large");
+    EXPECT_EQ(cat.message(msg::error::message_expired), "Message expired");
+    EXPECT_EQ(cat.message(msg::error::invalid_payload), "Invalid message payload");
+    EXPECT_EQ(cat.message(msg::error::message_serialization_failed), "Message serialization failed");
+    EXPECT_EQ(cat.message(msg::error::message_deserialization_failed), "Message deserialization failed");
+}
+
+TEST(MessagingErrorCategoryTest, TaskErrorCodes) {
+    const auto& cat = msg::messaging_error_category::instance();
+
+    EXPECT_EQ(cat.message(msg::error::task_not_found), "Task not found");
+    EXPECT_EQ(cat.message(msg::error::task_already_running), "Task already running");
+    EXPECT_EQ(cat.message(msg::error::task_timeout), "Task timeout");
+    EXPECT_EQ(cat.message(msg::error::task_failed), "Task execution failed");
+}
+
+TEST(MessagingErrorCategoryTest, RoutingErrorCodes) {
+    const auto& cat = msg::messaging_error_category::instance();
+
+    EXPECT_EQ(cat.message(msg::error::routing_failed), "Message routing failed");
+    EXPECT_EQ(cat.message(msg::error::unknown_topic), "Unknown topic");
+    EXPECT_EQ(cat.message(msg::error::no_subscribers), "No subscribers for topic");
+}
+
+TEST(MessagingErrorCategoryTest, QueueErrorCodes) {
+    const auto& cat = msg::messaging_error_category::instance();
+
+    EXPECT_EQ(cat.message(msg::error::queue_full), "Message queue full");
+    EXPECT_EQ(cat.message(msg::error::queue_empty), "Message queue empty");
+    EXPECT_EQ(cat.message(msg::error::queue_stopped), "Message queue stopped");
+    EXPECT_EQ(cat.message(msg::error::dlq_full), "Dead letter queue full");
+    EXPECT_EQ(cat.message(msg::error::dlq_not_configured), "Dead letter queue not configured");
+}
+
+TEST(MessagingErrorCategoryTest, SubscriptionErrorCodes) {
+    const auto& cat = msg::messaging_error_category::instance();
+
+    EXPECT_EQ(cat.message(msg::error::subscription_failed), "Subscription failed");
+    EXPECT_EQ(cat.message(msg::error::duplicate_subscription), "Duplicate subscription");
+}
+
+TEST(MessagingErrorCategoryTest, PublishingErrorCodes) {
+    const auto& cat = msg::messaging_error_category::instance();
+
+    EXPECT_EQ(cat.message(msg::error::publication_failed), "Publication failed");
+    EXPECT_EQ(cat.message(msg::error::broker_unavailable), "Message broker unavailable");
+    EXPECT_EQ(cat.message(msg::error::not_running), "Message bus not running");
+    EXPECT_EQ(cat.message(msg::error::not_supported), "Feature not supported (requires optional dependency)");
+}
+
+TEST(MessagingErrorCategoryTest, TransportErrorCodes) {
+    const auto& cat = msg::messaging_error_category::instance();
+
+    EXPECT_EQ(cat.message(msg::error::connection_failed), "Connection failed");
+    EXPECT_EQ(cat.message(msg::error::send_timeout), "Send operation timed out");
+    EXPECT_EQ(cat.message(msg::error::authentication_failed), "Authentication failed");
+    EXPECT_EQ(cat.message(msg::error::not_connected), "Transport not connected");
+}
+
+TEST(MessagingErrorCategoryTest, UnknownCode) {
+    const auto& cat = msg::messaging_error_category::instance();
+
+    EXPECT_EQ(cat.message(0), "Unknown messaging error");
+    EXPECT_EQ(cat.message(-999), "Unknown messaging error");
+}
+
+// =============================================================================
+// typed_error_code Integration Tests
+// =============================================================================
+
+TEST(MessagingErrorCategoryTest, MakeMessagingErrorCode) {
+    auto ec = msg::make_messaging_error_code(msg::error::queue_full);
+
+    EXPECT_EQ(ec.value(), msg::error::queue_full);
+    EXPECT_EQ(ec.category().name(), "messaging");
+    EXPECT_EQ(ec.message(), "Message queue full");
+    EXPECT_TRUE(static_cast<bool>(ec));
+}
+
+TEST(MessagingErrorCategoryTest, MakeTypedErrorCodeTemplate) {
+    auto ec = cmn::make_typed_error_code<msg::messaging_error_category>(
+        msg::error::routing_failed);
+
+    EXPECT_EQ(ec.value(), msg::error::routing_failed);
+    EXPECT_EQ(ec.category().name(), "messaging");
+    EXPECT_EQ(ec.message(), "Message routing failed");
+}
+
+TEST(MessagingErrorCategoryTest, CategoryComparison) {
+    auto messaging_ec = msg::make_messaging_error_code(msg::error::queue_full);
+    auto common_ec = cmn::make_typed_error_code(cmn::common_error_category::timeout);
+
+    // Different categories
+    EXPECT_NE(messaging_ec.category(), common_ec.category());
+
+    // Same category
+    auto messaging_ec2 = msg::make_messaging_error_code(msg::error::queue_empty);
+    EXPECT_EQ(messaging_ec.category(), messaging_ec2.category());
+}
+
+TEST(MessagingErrorCategoryTest, ErrorCodeEquality) {
+    auto ec1 = msg::make_messaging_error_code(msg::error::queue_full);
+    auto ec2 = msg::make_messaging_error_code(msg::error::queue_full);
+    auto ec3 = msg::make_messaging_error_code(msg::error::queue_empty);
+
+    EXPECT_EQ(ec1, ec2);
+    EXPECT_NE(ec1, ec3);
+}
+
+TEST(MessagingErrorCategoryTest, ResultIntegration) {
+    auto ec = msg::make_messaging_error_code(msg::error::subscription_failed);
+    auto result = cmn::Result<int>::err(ec);
+
+    EXPECT_FALSE(result.is_ok());
+}


### PR DESCRIPTION
Closes #229

## Summary
- Add `messaging_error_category` class inheriting from `common::error_category` for type-safe error codes
- Add `make_messaging_error_code()` convenience function for creating `typed_error_code` instances
- Add 15 unit tests covering singleton identity, all error code categories, `typed_error_code` integration, and `Result<T>` compatibility

## Details
The new `messaging_error_category` follows the same singleton pattern as `common_error_category` and delegates to the existing `get_error_message()` function. This enables:
- Type-safe error codes that carry their origin category (`"messaging"`)
- Direct integration with `Result<T>` via `typed_error_code`
- Category-based error comparison between messaging and common errors

This is Part 1 of Issue #220. Part 2 (#230) will migrate existing `make_error()` call sites to use `typed_error_code`.

## Test Plan
- [x] 15 unit tests pass (singleton, all 5 error categories, typed_error_code, Result integration)
- [x] Build passes with monitoring OFF
- [x] Build passes with monitoring ON
- [x] No regressions in existing 170 tests (3 pre-existing failures)