### PR TITLE
refactor(adapters): replace local circuit breaker with common_system resilience module (Issue #221)

### DIFF
--- a/examples/network/http_messaging.cpp
+++ b/examples/network/http_messaging.cpp
@@ -299,8 +299,8 @@ int main() {
 
         // Circuit breaker configuration
         resilient_config.circuit_breaker.failure_threshold = 5;
-        resilient_config.circuit_breaker.reset_timeout = std::chrono::seconds(30);
-        resilient_config.circuit_breaker.half_open_max_calls = 3;
+        resilient_config.circuit_breaker.timeout = std::chrono::seconds(30);
+        resilient_config.circuit_breaker.half_open_max_requests = 3;
 
         auto resilient = std::make_shared<resilient_transport>(
             http, resilient_config);
@@ -308,13 +308,13 @@ int main() {
         // Set up monitoring
         resilient->set_circuit_state_handler([](circuit_state state) {
             switch (state) {
-                case circuit_state::closed:
+                case circuit_state::CLOSED:
                     std::cout << "[Circuit] Closed - Normal operation\n";
                     break;
-                case circuit_state::open:
+                case circuit_state::OPEN:
                     std::cout << "[Circuit] Open - Failing fast\n";
                     break;
-                case circuit_state::half_open:
+                case circuit_state::HALF_OPEN:
                     std::cout << "[Circuit] Half-open - Testing recovery\n";
                     break;
             }

--- a/examples/network/websocket_realtime.cpp
+++ b/examples/network/websocket_realtime.cpp
@@ -53,7 +53,7 @@ public:
         resilient_transport_config resilient_config;
         resilient_config.retry.max_retries = 3;
         resilient_config.circuit_breaker.failure_threshold = 5;
-        resilient_config.circuit_breaker.reset_timeout = std::chrono::seconds(30);
+        resilient_config.circuit_breaker.timeout = std::chrono::seconds(30);
 
         transport_ = std::make_shared<resilient_transport>(
             ws_transport, resilient_config);


### PR DESCRIPTION
Closes #221

## Summary
- Replace local `circuit_state` enum and `circuit_breaker_config` struct in `resilient_transport.h` with `using` declarations from `common::resilience`
- Update field name references: `reset_timeout` -> `timeout`, `half_open_max_calls` -> `half_open_max_requests`
- Update enum value references: `closed`/`open`/`half_open` -> `CLOSED`/`OPEN`/`HALF_OPEN`
- Update example files (`websocket_realtime.cpp`, `http_messaging.cpp`) to use new API

## Details

The local circuit breaker types in `resilient_transport.h` are replaced with type aliases (`using`) from `common::resilience`, eliminating code duplication. The common_system provides:
- `circuit_state` enum with uppercase values (CLOSED, OPEN, HALF_OPEN)
- `circuit_breaker_config` with standardized field names
- `circuit_breaker` class with thread-safe state management and RAII guard

Note: The C++20 module file (`integration.cppm`) is deferred to Issue #223, as common_system does not yet export resilience types through its module system.

## Test Plan
- [x] Build passes with monitoring OFF (all 170 tests, 167 pass, 3 pre-existing failures)
- [x] Core library builds with monitoring ON
- [x] No regressions from this change