### PR TITLE
refactor(error): add typed error code enum to messaging_error_category (#220)

### DIFF
--- a/include/kcenon/messaging/error/messaging_error_category.h
+++ b/include/kcenon/messaging/error/messaging_error_category.h
@@ -16,12 +16,14 @@
  * @code
  * #include <kcenon/messaging/error/messaging_error_category.h>
  *
- * // Create a typed error code
- * auto ec = kcenon::messaging::make_messaging_error_code(
- *     kcenon::messaging::error::queue_full);
+ * // Preferred: use codes enum with make_typed_error_code
+ * auto ec = make_typed_error_code(messaging_error_category::queue_full);
  *
  * // Use with Result<T>
- * return Result<void>::err(ec);
+ * return Result<int>::err(ec);
+ *
+ * // Alternative: use make_messaging_error_code with int constants
+ * auto ec2 = make_messaging_error_code(error::queue_full);
  *
  * // Check category
  * if (ec.category() == messaging_error_category::instance()) {
@@ -55,6 +57,86 @@ namespace kcenon::messaging {
  */
 class messaging_error_category : public common::error_category {
 public:
+    /**
+     * @brief Typed error code enumeration for messaging_system
+     *
+     * Mirrors the constexpr int values from error_codes.h, enabling
+     * type-safe error code construction via make_typed_error_code().
+     * Follows the same pattern as common_error_category::codes.
+     *
+     * @code
+     * auto ec = make_typed_error_code(messaging_error_category::queue_full);
+     * return Result<int>::err(ec);
+     * @endcode
+     */
+    enum codes : int {
+        // Message errors (-700 to -719)
+        invalid_message = error::invalid_message,
+        message_too_large = error::message_too_large,
+        message_expired = error::message_expired,
+        invalid_payload = error::invalid_payload,
+        message_serialization_failed = error::message_serialization_failed,
+        message_deserialization_failed = error::message_deserialization_failed,
+
+        // Task errors (-706 to -715)
+        task_not_found = error::task_not_found,
+        task_already_running = error::task_already_running,
+        task_cancelled = error::task_cancelled,
+        task_timeout = error::task_timeout,
+        task_failed = error::task_failed,
+        task_handler_not_found = error::task_handler_not_found,
+        task_spawner_not_configured = error::task_spawner_not_configured,
+        task_invalid_argument = error::task_invalid_argument,
+        task_operation_failed = error::task_operation_failed,
+        schedule_already_exists = error::schedule_already_exists,
+
+        // Routing errors (-720 to -739)
+        routing_failed = error::routing_failed,
+        unknown_topic = error::unknown_topic,
+        no_subscribers = error::no_subscribers,
+        invalid_topic_pattern = error::invalid_topic_pattern,
+        route_not_found = error::route_not_found,
+
+        // Queue errors (-740 to -759)
+        queue_full = error::queue_full,
+        queue_empty = error::queue_empty,
+        queue_stopped = error::queue_stopped,
+        enqueue_failed = error::enqueue_failed,
+        dequeue_failed = error::dequeue_failed,
+        queue_timeout = error::queue_timeout,
+        dlq_full = error::dlq_full,
+        dlq_empty = error::dlq_empty,
+        dlq_message_not_found = error::dlq_message_not_found,
+        dlq_replay_failed = error::dlq_replay_failed,
+        dlq_not_configured = error::dlq_not_configured,
+
+        // Subscription errors (-760 to -779)
+        subscription_failed = error::subscription_failed,
+        subscription_not_found = error::subscription_not_found,
+        duplicate_subscription = error::duplicate_subscription,
+        unsubscribe_failed = error::unsubscribe_failed,
+        invalid_subscription = error::invalid_subscription,
+
+        // Publishing errors (-780 to -799)
+        publication_failed = error::publication_failed,
+        no_route_found = error::no_route_found,
+        message_rejected = error::message_rejected,
+        broker_unavailable = error::broker_unavailable,
+        broker_not_started = error::broker_not_started,
+        already_running = error::already_running,
+        not_running = error::not_running,
+        backend_not_ready = error::backend_not_ready,
+        request_timeout = error::request_timeout,
+        not_supported = error::not_supported,
+
+        // Transport errors (-790 to -794)
+        connection_failed = error::connection_failed,
+        send_timeout = error::send_timeout,
+        receive_timeout = error::receive_timeout,
+        authentication_failed = error::authentication_failed,
+        not_connected = error::not_connected,
+    };
+
     /**
      * @brief Returns the singleton instance
      *
@@ -109,6 +191,26 @@ private:
  */
 inline common::typed_error_code make_messaging_error_code(int code) noexcept {
     return common::typed_error_code(code, messaging_error_category::instance());
+}
+
+/**
+ * @brief Create a typed_error_code from messaging_error_category::codes enum
+ *
+ * ADL-discoverable overload that follows the common_system pattern.
+ * Enables type-safe error code construction without specifying the category.
+ *
+ * @param code Messaging error code enum value
+ * @return typed_error_code with messaging_error_category
+ *
+ * @code
+ * auto ec = make_typed_error_code(messaging_error_category::queue_full);
+ * return Result<int>::err(ec);
+ * @endcode
+ */
+inline common::typed_error_code make_typed_error_code(
+    messaging_error_category::codes code) noexcept {
+    return common::typed_error_code(
+        static_cast<int>(code), messaging_error_category::instance());
 }
 
 } // namespace kcenon::messaging


### PR DESCRIPTION
Closes #220

## Summary

- Add `codes` enum inside `messaging_error_category` that mirrors all 46 constexpr int error codes from `error_codes.h`
- Add `make_typed_error_code(messaging_error_category::codes)` overload for type-safe error code construction
- Add 7 new unit tests covering enum values, Result<T> integration, and backward compatibility

## Context

This completes the remaining phases of Issue #220:
- **Phase 1** (error category definition): Already completed in PR #229
- **Phase 2** (typed error codes): Implemented here via `codes` enum
- **Phase 3** (call site migration): Tracked separately in Issue #230
- **Phase 4** (backward compatibility): Existing `constexpr int` codes and `make_messaging_error_code()` remain unchanged
- **Phase 5** (testing): 7 new tests added (24 total in test file)

## Design

Follows the same pattern as `common_error_category::codes`:

```cpp
// Type-safe error code construction
auto ec = make_typed_error_code(messaging_error_category::queue_full);
return Result<int>::err(ec);

// Backward-compatible integer construction (still works)
auto ec2 = make_messaging_error_code(error::queue_full);
```

The `codes` enum uses unscoped `enum codes : int` (not `enum class`) so values are accessible directly as `messaging_error_category::queue_full` without the extra `codes::` qualifier.

## Test Plan

- [x] All 24 messaging error category tests pass
- [x] Full test suite passes (167/171, 4 pre-existing flaky failures)
- [x] Enum values verified identical to constexpr int constants
- [x] Enum-based and int-based construction produce equal `typed_error_code` objects
- [x] Result<T> integration works with both constructor and factory method
- [x] Cross-category inequality verified