### PR TITLE
fix(ci): resolve Windows test failures and stop swallowing test errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
         fetch-depth: 1
         token: ${{ secrets.GITHUB_TOKEN }}
 
+    # Dependencies are cloned from HEAD of each repo's default branch.
+    # If a dependency has test failures, they must be fixed upstream first.
+    # To debug: check the "Log dependency versions" step for exact commits used.
     - name: Checkout dependencies (Unix)
       if: runner.os != 'Windows'
       run: |
@@ -67,6 +70,25 @@ jobs:
         git clone --depth 1 https://github.com/kcenon/container_system.git
         git clone --depth 1 https://github.com/kcenon/network_system.git
         git clone --depth 1 https://github.com/kcenon/monitoring_system.git
+
+    - name: Log dependency versions (Unix)
+      if: runner.os != 'Windows'
+      run: |
+        echo "=== Dependency commits cloned for this CI run ==="
+        for dep in common_system thread_system logger_system container_system network_system monitoring_system; do
+          commit=$(git -C "../$dep" rev-parse HEAD)
+          echo "$dep: $commit"
+        done
+
+    - name: Log dependency versions (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        Write-Host "=== Dependency commits cloned for this CI run ==="
+        foreach ($dep in @("common_system","thread_system","logger_system","container_system","network_system","monitoring_system")) {
+          $commit = git -C "../$dep" rev-parse HEAD
+          Write-Host "${dep}: $commit"
+        }
 
     - name: Install dependencies (Ubuntu)
       if: runner.os == 'Linux'
@@ -237,10 +259,9 @@ jobs:
         # These tests pass on macOS and Windows but have issues on Linux
         if [ "$RUNNER_OS" = "Linux" ]; then
           ctest --output-on-failure --timeout 120 \
-            -E "TaskLifecycleTest|WorkerScenariosTest|FailureRecoveryTest|SchedulingTest|ConcurrentLoadTest" \
-            || echo "Some tests failed"
+            -E "TaskLifecycleTest|WorkerScenariosTest|FailureRecoveryTest|SchedulingTest|ConcurrentLoadTest"
         else
-          ctest --output-on-failure --timeout 120 || echo "Some tests failed"
+          ctest --output-on-failure --timeout 120
         fi
 
     - name: Run tests (Windows)
@@ -248,10 +269,12 @@ jobs:
       shell: pwsh
       run: |
         cd build
-        # Run tests with timeout and parallel execution
         # Exclude test_request_reply due to known flaky behavior on Windows
         ctest -C $env:BUILD_TYPE --output-on-failure --timeout 120 --parallel 4 -E "test_request_reply"
-        if ($LASTEXITCODE -ne 0) { Write-Host "Some tests failed" }
+        if ($LASTEXITCODE -ne 0) {
+          Write-Host "::error::Some tests failed on Windows"
+          exit $LASTEXITCODE
+        }
 
     - name: Upload test results
       if: always()
@@ -338,8 +361,7 @@ jobs:
       run: |
         cd build
         ctest --output-on-failure --timeout 120 \
-          -E "TaskLifecycleTest|WorkerScenariosTest|FailureRecoveryTest|SchedulingTest|ConcurrentLoadTest" \
-          || echo "Some tests failed"
+          -E "TaskLifecycleTest|WorkerScenariosTest|FailureRecoveryTest|SchedulingTest|ConcurrentLoadTest"
 
   # Sanitizer testing disabled temporarily due to fmt dependency issues
   # Will be re-enabled once thread_system fmt dependency is resolved


### PR DESCRIPTION
## What

Fix Windows CI test failures caused by upstream monitoring_system dependency tests, and
correct test error handling across all platforms to prevent silent test failures.

### Change Type
- [x] Bugfix (fixes an issue)
- [x] Chore (CI/workflow improvement)

### Affected Components
- `.github/workflows/ci.yml` - CI workflow test execution and dependency management

## Why

### Problem Solved
PRs #239 and #241 were both merged with Windows CI failures (3 monitoring_system tests
failing on Windows: `SystemResourceCollectorTest.ContextSwitchMonitoring`,
`MetricsProviderTest.TemperatureAvailabilityCheck`, `StressPerformanceTest.HighLoadStressTest`).

These failures originated from the monitoring_system dependency, which has since been fixed
upstream (monitoring_system PRs #610 and #611, both merged to main). Since this CI clones
dependencies from HEAD via `git clone --depth 1`, this PR's CI run will pick up the fixes.

Additionally, **test failures were being silently swallowed** on all platforms:
- Unix: `ctest ... || echo "Some tests failed"` always exits 0
- Windows: `if ($LASTEXITCODE -ne 0) { Write-Host "..." }` exits 0 from Write-Host
- This allowed PRs to be merged even when tests were actually failing

### Related Issues
- Resolves the Windows test failures present in PRs #239 and #241

## Where

### Files Changed
| File | Type of Change |
|------|----------------|
| `.github/workflows/ci.yml` | Fix test error propagation, add dependency version logging |

## How

### Changes Made

1. **Remove error-swallowing patterns**: Remove `|| echo "Some tests failed"` from Unix
   test steps and fix Windows PowerShell to explicitly `exit $LASTEXITCODE` on failure.
   Test failures now properly fail the CI job on all platforms.

2. **Add dependency version logging**: New "Log dependency versions" steps (Unix and Windows)
   that print the exact commit SHA of each cloned dependency. This makes it easy to diagnose
   whether a dependency test failure is due to an outdated upstream clone.

3. **Document dependency cloning behavior**: Add comments explaining that dependencies are
   cloned from HEAD of each repo's default branch, and that upstream fixes must be merged
   before they take effect in this CI.

### Testing
- This PR triggers a fresh CI run that will clone the latest monitoring_system (which
  includes the Windows test fixes from PRs #610 and #611)
- All 8 originally-failing tests should now pass (5 were already fixed in the prior
  CI run, and the remaining 3 are fixed by the latest monitoring_system HEAD)
- The dependency version log will confirm the correct monitoring_system commit was used