### PR TITLE
chore(ci): adopt setup-vcpkg composite action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,58 +109,10 @@ jobs:
           echo "VCPKG_FORCE_SYSTEM_BINARIES=arm" >> $GITHUB_ENV
         fi
 
-    - name: Cache vcpkg
-      uses: actions/cache@v4
-      id: vcpkg-cache
+    - name: Setup vcpkg
+      uses: kcenon/common_system/.github/actions/setup-vcpkg@main
       with:
-        path: |
-          ${{ github.workspace }}/vcpkg
-          !${{ github.workspace }}/vcpkg/buildtrees
-          !${{ github.workspace }}/vcpkg/packages
-          !${{ github.workspace }}/vcpkg/downloads
-        key: ${{ runner.os }}-${{ matrix.compiler }}-vcpkg-tool-${{ hashFiles('vcpkg.json') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.compiler }}-vcpkg-tool-
-
-    - name: Set up vcpkg (Unix)
-      if: runner.os != 'Windows'
-      run: |
-        if [ ! -d "vcpkg" ]; then
-          git clone https://github.com/Microsoft/vcpkg.git
-        fi
-        cd vcpkg
-        if [ "${{ steps.vcpkg-cache.outputs.cache-hit }}" != "true" ]; then
-          git pull
-          ./bootstrap-vcpkg.sh
-        fi
-        cd ..
-
-    - name: Set up vcpkg (Windows)
-      if: runner.os == 'Windows'
-      shell: pwsh
-      run: |
-        if (!(Test-Path "vcpkg")) {
-          git clone https://github.com/Microsoft/vcpkg.git
-        }
-        cd vcpkg
-        if ("${{ steps.vcpkg-cache.outputs.cache-hit }}" -ne "true") {
-          git pull
-          .\bootstrap-vcpkg.bat
-        }
-        cd ..
-
-    - name: Determine vcpkg commit (Unix)
-      if: runner.os != 'Windows'
-      id: vcpkg-commit-unix
-      run: echo "commit=$(git -C vcpkg rev-parse HEAD)" >> $GITHUB_OUTPUT
-
-    - name: Determine vcpkg commit (Windows)
-      if: runner.os == 'Windows'
-      id: vcpkg-commit-windows
-      shell: pwsh
-      run: |
-        $commit = git -C vcpkg rev-parse HEAD
-        "commit=$commit" >> $env:GITHUB_OUTPUT
+        extra-cache-key: 'messaging-system'
 
     # Cache vcpkg_installed for Unix only (Windows uses vcpkg binary caching via x-gha)
     - name: Cache vcpkg installed (Unix)
@@ -169,14 +121,14 @@ jobs:
       id: vcpkg-installed
       with:
         path: ${{ github.workspace }}/vcpkg_installed
-        key: ${{ runner.os }}-${{ matrix.compiler }}-vcpkg-installed-${{ matrix.triplet }}-testing-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}-${{ steps.vcpkg-commit-unix.outputs.commit }}
+        key: ${{ runner.os }}-${{ matrix.compiler }}-vcpkg-installed-${{ matrix.triplet }}-testing-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
         restore-keys: |
           ${{ runner.os }}-${{ matrix.compiler }}-vcpkg-installed-${{ matrix.triplet }}-testing-
 
     - name: Install dependencies with vcpkg (Unix)
       if: runner.os != 'Windows' && steps.vcpkg-installed.outputs.cache-hit != 'true'
       run: |
-        ./vcpkg/vcpkg install --x-manifest-root=. --x-install-root=${{ github.workspace }}/vcpkg_installed --triplet ${{ matrix.triplet }} --x-feature=testing || echo "vcpkg install failed, will use system libraries"
+        ${{ env.VCPKG_ROOT }}/vcpkg install --x-manifest-root=. --x-install-root=${{ github.workspace }}/vcpkg_installed --triplet ${{ matrix.triplet }} --x-feature=testing || echo "vcpkg install failed, will use system libraries"
 
     # Windows: vcpkg toolchain handles installation in manifest mode
     # Uses binary caching (VCPKG_BINARY_SOURCES) for build speed
@@ -220,7 +172,7 @@ jobs:
           -DMESSAGING_BUILD_EXAMPLES=OFF `
           -DMESSAGING_USE_LOCAL_SYSTEMS=ON `
           -DCMAKE_BUILD_TYPE=$env:BUILD_TYPE `
-          -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}\vcpkg\scripts\buildsystems\vcpkg.cmake `
+          -DCMAKE_TOOLCHAIN_FILE=${{ env.CMAKE_TOOLCHAIN_FILE }} `
           -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }} `
           -DVCPKG_MANIFEST_FEATURES=testing
 


### PR DESCRIPTION
## What

Migrate messaging_system CI workflow from inline vcpkg setup logic to the reusable
composite action at `kcenon/common_system/.github/actions/setup-vcpkg/`.

### Change Type
- [x] Chore (CI/CD maintenance)

### Affected Components
- `.github/workflows/ci.yml` — vcpkg setup steps in the `build` job

## Why

### Problem Solved
The inline vcpkg setup duplicates 54 lines of clone/bootstrap/cache logic that is
already encapsulated in the ecosystem composite action. This creates maintenance
burden — a bug fix in setup logic would require separate PRs in each repo.

### Related Issues
- Part of kcenon/common_system#512 (adopt setup-vcpkg composite action across ecosystem)
- Composite action created in kcenon/common_system#511

### Benefits
- Pins vcpkg to ecosystem baseline commit (previously cloned from HEAD)
- Standardizes cache key strategy across repos
- Reduces CI workflow from ~310 lines to ~260 lines
- Future vcpkg setup changes only need one PR (in common_system)

## Where

### Files Changed
| File | Lines Changed | Type of Change |
|------|:---:|---|
| `.github/workflows/ci.yml` | +6 / -54 | Replace inline vcpkg with composite action |

### Specific Changes
1. Removed 5 inline steps: Cache vcpkg, Setup Unix/Windows, Determine commit Unix/Windows
2. Added 1 composite action step: `kcenon/common_system/.github/actions/setup-vcpkg@main`
3. Updated `vcpkg` binary path to `${{ env.VCPKG_ROOT }}/vcpkg`
4. Updated Windows CMake toolchain to `${{ env.CMAKE_TOOLCHAIN_FILE }}`
5. Simplified `vcpkg_installed` cache key (removed dynamic commit hash)

## How

### Implementation Details
The composite action handles:
- Caching vcpkg directory with proper exclusions (buildtrees, packages, downloads)
- Cloning vcpkg pinned to ecosystem baseline commit `d90a9b15`
- Bootstrapping vcpkg (cross-platform)
- Setting `VCPKG_ROOT` and `CMAKE_TOOLCHAIN_FILE` environment variables

The `build-without-network` job is unchanged — it does not use vcpkg.

### Test Plan
- [ ] CI passes on all 3 platforms (Ubuntu, macOS, Windows)
- [ ] vcpkg cache is restored correctly
- [ ] vcpkg_installed packages cache works
- [ ] Build and tests succeed as before

### Breaking Changes
None — only CI infrastructure change, no source code modifications.